### PR TITLE
Add broker_state option to rabbitmq_plugin.

### DIFF
--- a/plugins/modules/rabbitmq_plugin.py
+++ b/plugins/modules/rabbitmq_plugin.py
@@ -40,6 +40,11 @@ options:
       - Specify if plugins are to be enabled or disabled.
     default: enabled
     choices: [enabled, disabled]
+  broker_state:
+    description:
+      - Specify whether the broker should be online or offline for the plugin change.
+    default: online
+    choices: [online, offline]
   prefix:
     description:
       - Specify a custom install prefix to a Rabbit.
@@ -66,6 +71,12 @@ EXAMPLES = '''
     names: rabbitmq_management,rabbitmq_management_visualiser,rabbitmq_shovel,rabbitmq_shovel_management
     state: enabled
     new_only: 'yes'
+
+- name: Enables the rabbitmq_peer_discovery_aws plugin without requiring a broker connection.
+  rabbitmq_plugin:
+    names: rabbitmq_management
+    state: enabled
+    broker_state: offline
 '''
 
 RETURN = '''
@@ -121,10 +132,10 @@ class RabbitMqPlugins(object):
         return plugins
 
     def enable(self, name):
-        self._exec(['enable', name])
+        self._exec(['enable', "--%s" % self.module.params['broker_state'], name])
 
     def disable(self, name):
-        self._exec(['disable', name])
+        self._exec(['disable', "--%s" % self.module.params['broker_state'], name])
 
 
 def main():
@@ -132,6 +143,7 @@ def main():
         names=dict(required=True, aliases=['name']),
         new_only=dict(default='no', type='bool'),
         state=dict(default='enabled', choices=['enabled', 'disabled']),
+        broker_state=dict(default='online', choices=['online', 'offline']),
         prefix=dict(required=False, default=None)
     )
     module = AnsibleModule(

--- a/plugins/modules/rabbitmq_plugin.py
+++ b/plugins/modules/rabbitmq_plugin.py
@@ -27,6 +27,7 @@ options:
   names:
     description:
       - Comma-separated list of plugin names. Also, accepts plugin name.
+    type: str
     required: true
     aliases: [name]
   new_only:
@@ -38,16 +39,19 @@ options:
   state:
     description:
       - Specify if plugins are to be enabled or disabled.
+    type: str
     default: enabled
     choices: [enabled, disabled]
   broker_state:
     description:
       - Specify whether the broker should be online or offline for the plugin change.
+    type: str
     default: online
     choices: [online, offline]
   prefix:
     description:
       - Specify a custom install prefix to a Rabbit.
+    type: str
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/rabbitmq_plugin.py
+++ b/plugins/modules/rabbitmq_plugin.py
@@ -78,7 +78,7 @@ EXAMPLES = '''
 
 - name: Enables the rabbitmq_peer_discovery_aws plugin without requiring a broker connection.
   rabbitmq_plugin:
-    names: rabbitmq_management
+    names: rabbitmq_peer_discovery_aws_plugin
     state: enabled
     broker_state: offline
 '''

--- a/tests/integration/targets/rabbitmq_plugin/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_plugin/tasks/tests.yml
@@ -2,7 +2,7 @@
   - set_fact:
       plugin_name: rabbitmq_top
 
-  - name: Enable plugin
+  - name: Enable plugin [online]
     rabbitmq_plugin:
       name: "{{ plugin_name }}"
       state: enabled
@@ -22,7 +22,7 @@
         - result.disabled == []
         - '"[E" in cli_result.stdout'
 
-  - name: Enable plugin (idempotency)
+  - name: Enable plugin [online] (idempotency)
     rabbitmq_plugin:
       name: "{{ plugin_name }}"
       state: enabled
@@ -34,7 +34,7 @@
       that:
         - result is not changed
 
-  - name: Disable plugin
+  - name: Disable plugin [online]
     rabbitmq_plugin:
       name: "{{ plugin_name }}"
       state: disabled
@@ -53,10 +53,76 @@
         - '"{{ plugin_name }}" in result.disabled'
         - '"[E" not in cli_result.stdout'
 
-  - name: Disable plugin (idempotency)
+  - name: Disable plugin [online] (idempotency)
     rabbitmq_plugin:
       name: "{{ plugin_name }}"
       state: disabled
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Enable plugin [offline]
+    rabbitmq_plugin:
+      name: "{{ plugin_name }}"
+      state: enabled
+      broker_state: offline
+      new_only: True
+    register: result
+
+  - name: Get rabbitmq-plugins output
+    shell: "rabbitmq-plugins list | grep {{ plugin_name }}"
+    register: cli_result
+
+  - name: Check that the plugin is enabled
+    assert:
+      that:
+        - result is changed
+        - result is success
+        - '"{{ plugin_name }}" in result.enabled'
+        - result.disabled == []
+        - '"[E" in cli_result.stdout'
+
+  - name: Enable plugin [offline] (idempotency)
+    rabbitmq_plugin:
+      name: "{{ plugin_name }}"
+      state: enabled
+      broker_state: offline
+      new_only: True
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Disable plugin [offline]
+    rabbitmq_plugin:
+      name: "{{ plugin_name }}"
+      state: disabled
+      broker_state: offline
+    register: result
+
+  - name: Get rabbitmq-plugins output
+    shell: "rabbitmq-plugins list | grep {{ plugin_name }}"
+    register: cli_result
+
+  - name: Check that the plugin is disabled
+    assert:
+      that:
+        - result is changed
+        - result is success
+        - result.enabled == []
+        - '"{{ plugin_name }}" in result.disabled'
+        - '"[E" not in cli_result.stdout'
+
+  - name: Disable plugin [offline] (idempotency)
+    rabbitmq_plugin:
+      name: "{{ plugin_name }}"
+      state: disabled
+      broker_state: offline
     register: result
 
   - name: Check idempotency


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds a `broker_state` option to `rabbitmq_plugin` that controls whether or not an attempt is made to connect to the node to change the plugin state.
Some plugins require the plugin enabled state to be modified directly, without connecting to the node first.
An example of this is [AWS Peer Discovery Plugin](https://github.com/rabbitmq/rabbitmq-peer-discovery-aws).

I wasn't sure what to call the option so if you have better suggestions, please let me know.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`rabbitmq_plugin`

##### ADDITIONAL INFORMATION
Further information on the option can be found in the [official RabbitMQ documentation on the command](https://www.rabbitmq.com/rabbitmq-plugins.8.html#-offline).
