### PR TITLE
Check RabbitMQ version and parse result of commands as JSON

### DIFF
--- a/changelogs/fragments/66876-parse_post_rabbitmq_3.7_output_as_json.yaml
+++ b/changelogs/fragments/66876-parse_post_rabbitmq_3.7_output_as_json.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Refactor RabbitMQ user module to first check the version of the daemon and then, when possible add flags to `rabbitmqctl` so that a machine readable  output is returned. Also, depending on the version, parse the output in correctly. Expands tests accordingly. (https://github.com/ansible/ansible/issues/48890)

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -127,8 +127,44 @@ EXAMPLES = '''
     state: present
 '''
 
+import distutils.version
+import json
+import re
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.collections import count
+
+
+def normalized_permissions(vhost_permission_list):
+    """Older versions of RabbitMQ output permissions with slightly different names.
+
+    In older versions of RabbitMQ, the names of the permissions had the `_priv` suffix, which was removed in versions
+    >= 3.7.6. For simplicity we only check the `configure` permission. If it's in the old format then all the other
+    ones will be wrong too.
+    """
+    for vhost_permission in vhost_permission_list:
+        if 'configure_priv' in vhost_permission:
+            yield {
+                'configure': vhost_permission['configure_priv'],
+                'read': vhost_permission['read_priv'],
+                'write': vhost_permission['write_priv'],
+                'vhost': vhost_permission['vhost']
+            }
+        else:
+            yield vhost_permission
+
+
+def as_permission_dict(vhost_permission_list):
+    return dict([(vhost_permission['vhost'], vhost_permission) for vhost_permission
+                 in normalized_permissions(vhost_permission_list)])
+
+
+def only(vhost, vhost_permissions):
+    return {vhost: vhost_permissions.get(vhost, {})}
+
+
+def first(iterable):
+    return next(iter(iterable))
 
 
 class RabbitMqUser(object):
@@ -136,84 +172,175 @@ class RabbitMqUser(object):
                  node, bulk_permissions=False):
         self.module = module
         self.username = username
-        self.password = password
+        self.password = password or ''
         self.node = node
-        if not tags:
-            self.tags = list()
-        else:
-            self.tags = tags.split(',')
-
-        self.permissions = permissions
+        self.tags = list() if not tags else tags.replace(' ', '').split(',')
+        self.permissions = as_permission_dict(permissions)
         self.bulk_permissions = bulk_permissions
 
-        self._tags = None
-        self._permissions = []
+        self.existing_tags = None
+        self.existing_permissions = dict()
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._version = self._check_version()
 
-    def _exec(self, args, run_in_check_mode=False, check_rc=True):
-        if not self.module.check_mode or run_in_check_mode:
-            cmd = [self._rabbitmqctl, '-q']
-            if self.node:
-                cmd.extend(['-n', self.node])
-            rc, out, err = self.module.run_command(cmd + args, check_rc=check_rc)
-            return out.splitlines()
-        return list()
+    def _check_version(self):
+        """Get the version of the RabbitMQ server."""
+        version = self._rabbitmq_version_post_3_7(fail_on_error=False)
+        if not version:
+            version = self._rabbitmq_version_pre_3_7(fail_on_error=False)
+        if not version:
+            self.module.fail_json(msg="Could not determine the version of the RabbitMQ server.")
+        return version
+
+    def _fail(self, msg, stop_execution=False):
+        if stop_execution:
+            self.module.fail_json(msg=msg)
+        # This is a dummy return to prevent linters from throwing errors.
+        return None
+
+    def _rabbitmq_version_post_3_7(self, fail_on_error=False):
+        """Use the JSON formatter to get a machine readable output of the version.
+
+        At this point we do not know which RabbitMQ server version we are dealing with and which
+        version of `rabbitmqctl` we are using, so we will try to use the JSON formatter and see
+        what happens. In some versions of
+        """
+        def int_list_to_str(ints):
+            return ''.join([chr(i) for i in ints])
+
+        rc, output, err = self._exec(['status', '--formatter', 'json'], check_rc=False)
+        if rc != 0:
+            return self._fail(msg="Could not parse the version of the RabbitMQ server, "
+                                  "because `rabbitmqctl status` returned no output.",
+                              stop_execution=fail_on_error)
+        try:
+            status_json = json.loads(output)
+            if 'rabbitmq_version' in status_json:
+                return distutils.version.StrictVersion(status_json['rabbitmq_version'])
+            for application in status_json.get('running_applications', list()):
+                if application[0] == 'rabbit':
+                    if isinstance(application[1][0], int):
+                        return distutils.version.StrictVersion(int_list_to_str(application[2]))
+                    else:
+                        return distutils.version.StrictVersion(application[1])
+            return self._fail(msg="Could not find RabbitMQ version of `rabbitmqctl status` command.",
+                              stop_execution=fail_on_error)
+        except ValueError as e:
+            return self._fail(msg="Could not parse output of `rabbitmqctl status` as JSON: {exc}.".format(exc=repr(e)),
+                              stop_execution=fail_on_error)
+
+    def _rabbitmq_version_pre_3_7(self, fail_on_error=False):
+        """Get the version of the RabbitMQ Server.
+
+        Before version 3.7.6 the `rabbitmqctl` utility did not support the
+        `--formatter` flag, so the output has to be parsed using regular expressions.
+        """
+        version_reg_ex = r"{rabbit,\"RabbitMQ\",\"([0-9]+\.[0-9]+\.[0-9]+)\"}"
+        rc, output, err = self._exec(['status'], check_rc=False)
+        if rc != 0:
+            if fail_on_error:
+                self.module.fail_json(msg="Could not parse the version of the RabbitMQ server, because"
+                                          " `rabbitmqctl status` returned no output.")
+            else:
+                return None
+        reg_ex_res = re.search(version_reg_ex, output, re.IGNORECASE)
+        if not reg_ex_res:
+            return self._fail(msg="Could not parse the version of the RabbitMQ server from the output of "
+                                  "`rabbitmqctl status` command: {output}.".format(output=output),
+                              stop_execution=fail_on_error)
+        try:
+            return distutils.version.StrictVersion(reg_ex_res.group(1))
+        except ValueError as e:
+            return self._fail(msg="Could not parse the version of the RabbitMQ server: {exc}.".format(exc=repr(e)),
+                              stop_execution=fail_on_error)
+
+    def _exec(self, args, check_rc=True):
+        """Execute a command using the `rabbitmqctl` utility.
+
+        By default the _exec call will cause the module to fail, if the error code is non-zero. If the `check_rc`
+        flag is set to False, then the exit_code, stdout and stderr will be returned to the calling function to
+        perform whatever error handling it needs.
+
+        :param args: the arguments to pass to the `rabbitmqctl` utility
+        :param check_rc: when set to True, fail if the utility's exit code is non-zero
+        :return: the output of the command or all the outputs plus the error code in case of error
+        """
+        cmd = [self._rabbitmqctl, '-q']
+        if self.node:
+            cmd.extend(['-n', self.node])
+        rc, out, err = self.module.run_command(cmd + args)
+        if check_rc and rc != 0:
+            # check_rc is not passed to the `run_command` method directly to allow for more fine grained checking of
+            # error messages returned by `rabbitmqctl`.
+            user_error_msg_regex = r"(Only root or .* .* run rabbitmqctl)"
+            user_error_msg = re.search(user_error_msg_regex, out)
+            if user_error_msg:
+                self.module.fail_json(msg="Wrong user used to run the `rabbitmqctl` utility: {err}"
+                                      .format(err=user_error_msg.group(1)))
+            else:
+                self.module.fail_json(msg="rabbitmqctl exited with non-zero code: {err}".format(err=err),
+                                      rc=rc, stdout=out)
+        return out if check_rc else (rc, out, err)
 
     def get(self):
-        users = self._exec(['list_users'], True)
+        """Retrieves the list of registered users from the node.
 
-        for user_tag in users:
-            if '\t' not in user_tag:
-                continue
+        If the user is already present, the node will also be queried for the user's permissions.
+        If the version of the node is >= 3.7.6 the JSON formatter will be used, otherwise the plaintext will be
+        parsed.
+        """
+        if self._version >= distutils.version.StrictVersion('3.7.6'):
+            users = dict([(user_entry['user'], user_entry['tags'])
+                          for user_entry in json.loads(self._exec(['list_users', '--formatter', 'json']))])
+        else:
+            users = self._exec(['list_users'])
 
-            user, tags = user_tag.split('\t')
+            def process_tags(tags):
+                if not tags:
+                    return list()
+                return tags.replace('[', '').replace(']', '').replace(' ', '').strip('\t').split(',')
 
-            if user == self.username:
-                for c in ['[', ']', ' ']:
-                    tags = tags.replace(c, '')
+            users_and_tags = [user_entry.split('\t') for user_entry in users.strip().split('\n')]
+            users = dict([(user, process_tags(tags)) for user, tags in users_and_tags])
 
-                if tags != '':
-                    self._tags = tags.split(',')
-                else:
-                    self._tags = list()
-
-                self._permissions = self._get_permissions()
-                return True
-        return False
+        self.existing_tags = users.get(self.username, list())
+        self.existing_permissions = self._get_permissions() if self.username in users else dict()
+        return self.username in users
 
     def _get_permissions(self):
         """Get permissions of the user from RabbitMQ."""
-        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
+        if self._version >= distutils.version.StrictVersion('3.7.6'):
+            permissions = json.loads(self._exec(['list_user_permissions', self.username, '--formatter', 'json']))
+        else:
+            output = self._exec(['list_user_permissions', self.username]).strip().split('\n')
+            perms_out = [perm.split('\t') for perm in output if perm.strip()]
+            # Filter out headers from the output of the command in case they are still present
+            perms_out = [perm for perm in perms_out if perm != ["vhost", "configure", "write", "read"]]
 
-        perms_list = list()
-        for perm in perms_out:
-            vhost, configure_priv, write_priv, read_priv = perm.split('\t')
-            if not self.bulk_permissions:
-                if vhost == self.permissions[0]['vhost']:
-                    perms_list.append(dict(vhost=vhost, configure_priv=configure_priv,
-                                           write_priv=write_priv, read_priv=read_priv))
-                    break
-            else:
-                perms_list.append(dict(vhost=vhost, configure_priv=configure_priv,
-                                       write_priv=write_priv, read_priv=read_priv))
-        return perms_list
+            permissions = list()
+            for vhost, configure, write, read in perms_out:
+                permissions.append(dict(vhost=vhost, configure=configure, write=write, read=read))
+
+        if self.bulk_permissions:
+            return as_permission_dict(permissions)
+        else:
+            return only(first(self.permissions.keys()), as_permission_dict(permissions))
 
     def check_password(self):
-        return self._exec(['authenticate_user', self.username, self.password],
-                          run_in_check_mode=True, check_rc=False)
+        """Return `True` if the user can authenticate successfully."""
+        rc, out, err = self._exec(['authenticate_user', self.username, self.password], check_rc=False)
+        return rc == 0
 
     def add(self):
-        if self.password is not None:
-            self._exec(['add_user', self.username, self.password])
-        else:
-            self._exec(['add_user', self.username, ''])
+        self._exec(['add_user', self.username, self.password or ''])
+        if not self.password:
             self._exec(['clear_password', self.username])
 
     def delete(self):
         self._exec(['delete_user', self.username])
 
     def change_password(self):
-        if self.password is not None:
+        if self.password:
             self._exec(['change_password', self.username, self.password])
         else:
             self._exec(['clear_password', self.username])
@@ -222,28 +349,30 @@ class RabbitMqUser(object):
         self._exec(['set_user_tags', self.username] + self.tags)
 
     def set_permissions(self):
-        permissions_to_clear = [permission for permission in self._permissions if permission not in self.permissions]
-        permissions_to_add = [permission for permission in self.permissions if permission not in self._permissions]
-        for permission in permissions_to_clear:
-            cmd = 'clear_permissions -p {vhost} {username}'.format(username=self.username,
-                                                                   vhost=permission['vhost'])
+        permissions_to_add = list()
+        for vhost, permission_dict in self.permissions.items():
+            if permission_dict != self.existing_permissions.get(vhost, {}):
+                permissions_to_add.append(permission_dict)
+
+        permissions_to_clear = list()
+        for vhost in self.existing_permissions.keys():
+            if vhost not in self.permissions:
+                permissions_to_clear.append(vhost)
+
+        for vhost in permissions_to_clear:
+            cmd = 'clear_permissions -p {vhost} {username}'.format(username=self.username, vhost=vhost)
             self._exec(cmd.split(' '))
-        for permission in permissions_to_add:
-            cmd = ('set_permissions -p {vhost} {username} {configure_priv} {write_priv} {read_priv}'
-                   .format(username=self.username, **permission))
+        for permissions in permissions_to_add:
+            cmd = ('set_permissions -p {vhost} {username} {configure} {write} {read}'
+                   .format(username=self.username, **permissions))
             self._exec(cmd.split(' '))
+        self.existing_permissions = self._get_permissions()
 
     def has_tags_modifications(self):
-        return set(self.tags) != set(self._tags)
+        return set(self.tags) != set(self.existing_tags)
 
     def has_permissions_modifications(self):
-        def to_permission_tuple(vhost_permission_dict):
-            return vhost_permission_dict['vhost'], vhost_permission_dict
-
-        def permission_dict(vhost_permission_list):
-            return dict(map(to_permission_tuple, vhost_permission_list))
-
-        return permission_dict(self._permissions) != permission_dict(self.permissions)
+        return self.existing_permissions != self.permissions
 
 
 def main():
@@ -280,9 +409,10 @@ def main():
     update_password = module.params['update_password']
 
     if permissions:
-        vhosts = map(lambda permission: permission.get('vhost', '/'), permissions)
-        if any(map(lambda count: count > 1, count(vhosts).values())):
-            module.fail_json(msg="Error parsing permissions: You can't have two permission dicts for the same vhost")
+        vhosts = [permission.get('vhost', '/') for permission in permissions]
+        if any([vhost_count > 1 for vhost_count in count(vhosts).values()]):
+            module.fail_json(msg="Error parsing vhost permissions: You can't "
+                                 "have two permission dicts for the same vhost")
         bulk_permissions = True
     else:
         perm = {
@@ -293,6 +423,11 @@ def main():
         }
         permissions.append(perm)
         bulk_permissions = False
+
+    for permission in permissions:
+        if not permission['vhost']:
+            module.fail_json(msg="Error parsing vhost permissions: You can't"
+                                 "have an empty vhost when setting permissions")
 
     rabbitmq_user = RabbitMqUser(module, username, password, tags, permissions,
                                  node, bulk_permissions=bulk_permissions)

--- a/tests/integration/targets/rabbitmq_user/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests.yml
@@ -1,17 +1,5 @@
 ---
 
-- name: Test add user in check mode
-  block:
-    - name: Add user
-      rabbitmq_user: user=joe password=changeme
-      check_mode: true
-      register: add_user
-
-    - name: Check that user adding succeeds with a change
-      assert:
-        that:
-          - add_user.changed == true
-
 - name: Test add user
   block:
     - name: Add user
@@ -33,18 +21,6 @@
       assert:
         that:
           - add_user.changed == false
-
-- name: Test change user permissions in check mode
-  block:
-    - name: Add user with permissions
-      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.*
-      check_mode: true
-      register: add_user
-
-    - name: Check that changing permissions succeeds with a change
-      assert:
-        that:
-          - add_user.changed == true
 
 - name: Test change user permissions
   block:
@@ -68,18 +44,6 @@
         that:
           - add_user.changed == false
 
-- name: Test add user tags in check mode
-  block:
-    - name: Add user with tags
-      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.* tags=management,administrator
-      check_mode: true
-      register: add_user
-
-    - name: Check that adding tags succeeds with a change
-      assert:
-        that:
-          - add_user.changed == true
-
 - name: Test add user tags
   block:
     - name: Add user with tags
@@ -101,18 +65,6 @@
       assert:
         that:
           - add_user.changed == false
-
-- name: Test remove user in check mode
-  block:
-    - name: Remove user
-      rabbitmq_user: user=joe state=absent
-      check_mode: true
-      register: remove_user
-
-    - name: Check that user removing succeeds with a change
-      assert:
-        that:
-          - remove_user.changed == true
 
 - name: Test remove user
   block:

--- a/tests/unit/modules/messaging/rabbitmq/rabbitmq_user_fixtures.py
+++ b/tests/unit/modules/messaging/rabbitmq/rabbitmq_user_fixtures.py
@@ -1,0 +1,181 @@
+rabbitmq_3_6_status = '''
+Status of node rabbit@vagrant
+[{pid,5519},
+ {running_applications,
+     [{rabbit,"RabbitMQ","version_num"},
+      {mnesia,"MNESIA  CXC 138 12","4.15.3"},
+      {ranch,"Socket acceptor pool for TCP protocols.","1.3.0"},
+      {ssl,"Erlang/OTP SSL application","8.2.3"},
+      {public_key,"Public key infrastructure","1.5.2"},
+      {asn1,"The Erlang ASN1 compiler version 5.0.4","5.0.4"},
+      {rabbit_common,
+          "Modules shared by rabbitmq-server and rabbitmq-erlang-client",
+          "3.6.10"},
+      {xmerl,"XML parser","1.3.16"},
+      {crypto,"CRYPTO","4.2"},
+      {compiler,"ERTS  CXC 138 10","7.1.4"},
+      {os_mon,"CPO  CXC 138 46","2.4.4"},
+      {syntax_tools,"Syntax tools","2.1.4"},
+      {sasl,"SASL  CXC 138 11","3.1.1"},
+      {stdlib,"ERTS  CXC 138 10","3.4.3"},
+      {kernel,"ERTS  CXC 138 10","5.4.1"}]},
+ {os,{unix,linux}},
+ {erlang_version,
+     "Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:64] [kernel-poll:true]\n"},
+ {memory,
+     [{total,49712064},
+      {connection_readers,0},
+      {connection_writers,0},
+      {connection_channels,0},
+      {connection_other,0},
+      {queue_procs,2744},
+      {queue_slave_procs,0},
+      {plugins,0},
+      {other_proc,17493000},
+      {mnesia,65128},
+      {metrics,184272},
+      {mgmt_db,0},
+      {msg_index,41832},
+      {other_ets,1766176},
+      {binary,43576},
+      {code,21390833},
+      {atom,891849},
+      {other_system,8014118}]},
+ {alarms,[]},
+ {listeners,[{clustering,25672,"::"},{amqp,5672,"::"}]},
+ {vm_memory_high_watermark,0.4},
+ {vm_memory_limit,413340467},
+ {disk_free_limit,50000000},
+ {disk_free,61216505856},
+ {file_descriptors,
+     [{total_limit,65436},
+      {total_used,2},
+      {sockets_limit,58890},
+      {sockets_used,0}]},
+ {processes,[{limit,1048576},{used,153}]},
+ {run_queue,0},
+ {uptime,1795},
+ {kernel,{net_ticktime,60}}]
+root@vagrant:/home/vagrant# rabbitmqctl -q status
+[{pid,5519},
+ {running_applications,
+     [{rabbit,"RabbitMQ","3.6.10"},
+      {mnesia,"MNESIA  CXC 138 12","4.15.3"},
+      {ranch,"Socket acceptor pool for TCP protocols.","1.3.0"},
+      {ssl,"Erlang/OTP SSL application","8.2.3"},
+      {public_key,"Public key infrastructure","1.5.2"},
+      {asn1,"The Erlang ASN1 compiler version 5.0.4","5.0.4"},
+      {rabbit_common,
+          "Modules shared by rabbitmq-server and rabbitmq-erlang-client",
+          "3.6.10"},
+      {xmerl,"XML parser","1.3.16"},
+      {crypto,"CRYPTO","4.2"},
+      {compiler,"ERTS  CXC 138 10","7.1.4"},
+      {os_mon,"CPO  CXC 138 46","2.4.4"},
+      {syntax_tools,"Syntax tools","2.1.4"},
+      {sasl,"SASL  CXC 138 11","3.1.1"},
+      {stdlib,"ERTS  CXC 138 10","3.4.3"},
+      {kernel,"ERTS  CXC 138 10","5.4.1"}]},
+ {os,{unix,linux}},
+ {erlang_version,
+     "Erlang/OTP 20 [erts-9.2] [source] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:64] [kernel-poll:true]\n"},
+ {memory,
+     [{total,49770912},
+      {connection_readers,0},
+      {connection_writers,0},
+      {connection_channels,0},
+      {connection_other,0},
+      {queue_procs,2744},
+      {queue_slave_procs,0},
+      {plugins,0},
+      {other_proc,17554528},
+      {mnesia,65128},
+      {metrics,184272},
+      {mgmt_db,0},
+      {msg_index,41832},
+      {other_ets,1766176},
+      {binary,42816},
+      {code,21390833},
+      {atom,891849},
+      {other_system,8012198}]},
+ {alarms,[]},
+ {listeners,[{clustering,25672,"::"},{amqp,5672,"::"}]},
+ {vm_memory_high_watermark,0.4},
+ {vm_memory_limit,413340467},
+ {disk_free_limit,50000000},
+ {disk_free,61216497664},
+ {file_descriptors,
+     [{total_limit,65436},
+      {total_used,2},
+      {sockets_limit,58890},
+      {sockets_used,0}]},
+ {processes,[{limit,1048576},{used,153}]},
+ {run_queue,0},
+ {uptime,17139},
+ {kernel,{net_ticktime,60}}]'''
+
+rabbitmq_3_7_status = \
+    '{"pid":31701,"running_applications":[' \
+    '["rabbit",[82,97,98,98,105,116,77,81],version_num],' \
+    '["rabbit_common",[77,111,100,117,108,101,115,32,115,104,97,114,101,100,32,98,121,32,114,97,98,98,105,116,109,' \
+    '113,45,115,101,114,118,101,114,32,97,110,100,32,114,97,98,98,105,116,109,113,45,101,114,108,97,110,103,45,99,' \
+    '108,105,101,110,116],[51,46,55,46,54]],' \
+    '["ranch_proxy_protocol",[82,97,110,99,104,32,80,114,111,120,121,32,80,114,111,116,111,99,111,108,32,84,114,97,' \
+    '110,115,112,111,114,116],[49,46,53,46,48]],' \
+    '["ranch",[83,111,99,107,101,116,32,97,99,99,101,112,116,111,114,32,112,111,111,108,32,102,111,114,32,84,67,80,' \
+    '32,112,114,111,116,111,99,111,108,115,46],[49,46,53,46,48]],["ssl",[69,114,108,97,110,103,47,79,84,80,32,83,83,' \
+    '76,32,97,112,112,108,105,99,97,116,105,111,110],[56,46,50,46,51]],' \
+    '["public_key",[80,117,98,108,105,99,32,107,101,121,32,105,110,102,114,97,115,116,114,117,99,116,117,114,101],' \
+    '[49,46,53,46,50]],' \
+    '["asn1",[84,104,101,32,69,114,108,97,110,103,32,65,83,78,49,32,99,111,109,112,105,108,101,114,32,118,101,114,' \
+    '115,105,111,110,32,53,46,48,46,52],[53,46,48,46,52]],' \
+    '["crypto",[67,82,89,80,84,79],[52,46,50]],["xmerl",[88,77,76,32,112,97,114,115,101,114],[49,46,51,46,49,54]],' \
+    '["recon",[68,105,97,103,110,111,115,116,105,99,32,116,111,111,108,115,32,102,111,114,32,112,114,111,100,117,99,' \
+    '116,105,111,110,32,117,115,101],[50,46,51,46,50]],' \
+    '["inets",[73,78,69,84,83,32,32,67,88,67,32,49,51,56,32,52,57],[54,46,52,46,53]],' \
+    '["jsx",[97,32,115,116,114,101,97,109,105,110,103,44,32,101,118,101,110,116,101,100,32,106,115,111,110,32,112,97,' \
+    '114,115,105,110,103,32,116,111,111,108,107,105,116],[50,46,56,46,50]],["os_mon",[67,80,79,32,32,67,88,67,32,49,' \
+    '51,56,32,52,54],[50,46,52,46,52]],' \
+    '["mnesia",[77,78,69,83,73,65,32,32,67,88,67,32,49,51,56,32,49,50],[52,46,49,53,46,51]],' \
+    '["lager",[69,114,108,97,110,103,32,108,111,103,103,105,110,103,32,102,114,97,109,101,119,111,114,107],' \
+    '[51,46,53,46,49]],' \
+    '["goldrush",[69,114,108,97,110,103,32,101,118,101,110,116,32,115,116,114,101,97,109,32,112,114,111,99,101,115,' \
+    '115,111,114],[48,46,49,46,57]],["compiler",[69,82,84,83,32,32,67,88,67,32,49,51,56,32,49,48],[55,46,49,46,52]],' \
+    '["syntax_tools",[83,121,110,116,97,120,32,116,111,111,108,115],[50,46,49,46,52]],' \
+    '["syslog",[65,110,32,82,70,67,32,51,49,54,52,32,97,110,100,32,82,70,67,32,53,52,50,52,32,99,111,109,112,108,' \
+    '105,97,110,116,32,108,111,103,103,105,110,103,32,102,114,97,109,101,119,111,114,107,46],[51,46,52,46,50]],' \
+    '["sasl",[83,65,83,76,32,32,67,88,67,32,49,51,56,32,49,49],[51,46,49,46,49]],' \
+    '["stdlib",[69,82,84,83,32,32,67,88,67,32,49,51,56,32,49,48],[51,46,52,46,51]],' \
+    '["kernel",[69,82,84,83,32,32,67,88,67,32,49,51,56,32,49,48],[53,46,52,46,49]]],' \
+    '"os":["unix","linux"],"erlang_version":[69,114,108,97,110,103,47,79,84,80,32,50,48,32,91,101,114,116,115,45,57,' \
+    '46,50,93,32,91,115,111,117,114,99,101,93,32,91,54,52,45,98,105,116,93,32,91,115,109,112,58,49,58,49,93,32,91,' \
+    '100,115,58,49,58,49,58,49,48,93,32,91,97,115,121,110,99,45,116,104,114,101,97,100,115,58,54,52,93,32,91,107,' \
+    '101,114,110,101,108,45,112,111,108,108,58,116,114,117,101,93,10],' \
+    '"memory":{"connection_readers":0,"connection_writers":0,"connection_channels":0,' \
+    '"connection_other":0,"queue_procs":0,"queue_slave_procs":0,"plugins":5736,"other_proc":23159832,' \
+    '"metrics":184608,"mgmt_db":0,"mnesia":76896,"other_ets":1882856,"binary":64120,"msg_index":57184,' \
+    '"code":24981937,"atom":1041593,"other_system":8993494,"allocated_unused":13066752,"reserved_unallocated":0,' \
+    '"strategy":"rss","total":{"erlang":60448256,"rss":72720384,"allocated":73515008}},"alarms":[],' \
+    '"listeners":[["clustering",25672,[58,58]],["amqp",5672,[58,58]]],"vm_memory_calculation_strategy":"rss",' \
+    '"vm_memory_high_watermark":0.4,"vm_memory_limit":413340467,"disk_free_limit":50000000,"disk_free":61108576256,' \
+    '"file_descriptors":{"total_limit":924,"total_used":4,"sockets_limit":829,"sockets_used":0},' \
+    '"processes":{"limit":1048576,"used":214},"run_queue":0,"uptime":173,"kernel":["net_ticktime",60]}'
+
+rabbitmq_3_8_status = \
+    '{"active_plugins":[],"alarms":[],"config_files":[],"data_directory":"/var/lib/rabbitmq/mnesia/rabbit@vagrant",' \
+    '"disk_free":60898615296,"disk_free_limit":50000000,"enabled_plugin_file":"/etc/rabbitmq/enabled_plugins",' \
+    '"erlang_version":"Erlang/OTP 21 [erts-10.3.5.8] [source] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:64]",' \
+    '"file_descriptors":{"sockets_limit":29399,"sockets_used":0,"total_limit":32668,"total_used":4},' \
+    '"listeners":[{"interface":"[::]","node":"rabbit@vagrant","port":25672,"protocol":"clustering",' \
+    '"purpose":"inter-node and CLI tool communication"},{"interface":"[::]","node":"rabbit@vagrant",' \
+    '"port":5672,"protocol":"amqp","purpose":"AMQP 0-9-1 and AMQP 1.0"}],' \
+    '"log_files":["/var/log/rabbitmq/rabbit@vagrant.log","/var/log/rabbitmq/rabbit@vagrant_upgrade.log"],' \
+    '"memory":{"allocated_unused":14962432,"atom":1180881,"binary":82304,"code":26631176,"connection_channels":0,' \
+    '"connection_other":0,"connection_readers":0,"connection_writers":0,"metrics":195308,"mgmt_db":0,"mnesia":76896,' \
+    '"msg_index":57088,"other_ets":2666736,"other_proc":25333896,"other_system":10068879,"plugins":11732,' \
+    '"queue_procs":0,"queue_slave_procs":0,"quorum_ets":42368,"quorum_queue_procs":0,"reserved_unallocated":0,' \
+    '"strategy":"rss","total":{"erlang":66347264,"rss":80506880,"allocated":81309696}},"net_ticktime":60,' \
+    '"os":"Linux","pid":9829,"processes":{"limit":1048576,"used":259},"rabbitmq_version":"version_num","run_queue":1,' \
+    '"totals":{"virtual_host_count":2,"connection_count":0,"queue_count":0},"uptime":66,' \
+    '"vm_memory_calculation_strategy":"rss","vm_memory_high_watermark_limit":413340467,' \
+    '"vm_memory_high_watermark_setting":{"relative":0.4}}'

--- a/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
+++ b/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
@@ -24,7 +24,7 @@ from ansible_collections.community.rabbitmq.tests.unit.modules.messaging.rabbitm
 
 
 def flatten(args):
-    return [e for e in chain(*args)]
+    return list(chain(*args))
 
 
 def lists_equal(l1, l2):

--- a/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
+++ b/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
@@ -3,9 +3,31 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import distutils.version
+
 from ansible_collections.community.rabbitmq.plugins.modules import rabbitmq_user
+from ansible.module_utils import six
+from itertools import chain
+
+if six.PY3:
+    from itertools import zip_longest
+else:
+    from itertools import izip_longest as zip_longest
+
 from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
 from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible_collections.community.rabbitmq.tests.unit.modules.messaging.rabbitmq.rabbitmq_user_fixtures import (rabbitmq_3_6_status,
+                                                                     rabbitmq_3_7_status,
+                                                                     rabbitmq_3_8_status)
+
+
+def flatten(args):
+    return [e for e in chain(*args)]
+
+
+def lists_equal(l1, l2):
+    return all(map(lambda t: t[0] == t[1], zip_longest(l1, l2)))
 
 
 class TestRabbitMQUserModule(ModuleTestCase):
@@ -16,39 +38,47 @@ class TestRabbitMQUserModule(ModuleTestCase):
     def tearDown(self):
         super(TestRabbitMQUserModule, self).tearDown()
 
-    def _assert(self, exc, attribute, expected_value, msg=""):
+    def _assert(self, exc, attribute, expected_value, msg=''):
         value = exc.message[attribute] if hasattr(exc, attribute) else exc.args[0][attribute]
         assert value == expected_value, msg
 
     def test_without_required_parameters(self):
-        """Failure must occurs when all parameters are missing"""
+        """Failure must occur when all parameters are missing."""
         with self.assertRaises(AnsibleFailJson):
             set_module_args({})
             self.module.main()
 
-    def test_permissions_with_same_vhost(self):
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    def test_permissions_with_same_vhost(self, _check_version, get_bin_path):
         set_module_args({
             'user': 'someuser',
             'password': 'somepassword',
             'state': 'present',
             'permissions': [{'vhost': '/'}, {'vhost': '/'}],
         })
-        with patch('ansible.module_utils.basic.AnsibleModule.get_bin_path') as get_bin_path:
-            get_bin_path.return_value = '/rabbitmqctl'
-            try:
-                self.module.main()
-            except AnsibleFailJson as e:
-                self._assert(e, 'failed', True)
-                self._assert(e, 'msg',
-                             "Error parsing permissions: You can't have two permission dicts for the same vhost")
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        get_bin_path.return_value = '/rabbitmqctl'
+        try:
+            self.module.main()
+        except AnsibleFailJson as e:
+            self._assert(e, 'failed', True)
+            self._assert(e, 'msg', "Error parsing vhost "
+                                   "permissions: You can't have two permission dicts for the same vhost")
 
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.get')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.check_password')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_permissions_modifications')
-    def test_password_changes_only_when_needed(self, has_permissions_modifications, has_tags_modifications,
-                                               check_password, get, get_bin_path):
+    def test_password_changes_only_when_needed(self,
+                                               has_permissions_modifications,
+                                               has_tags_modifications,
+                                               check_password,
+                                               _check_version,
+                                               get,
+                                               get_bin_path):
         set_module_args({
             'user': 'someuser',
             'password': 'somepassword',
@@ -56,6 +86,7 @@ class TestRabbitMQUserModule(ModuleTestCase):
             'update_password': 'always',
         })
         get.return_value = True
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
         get_bin_path.return_value = '/rabbitmqctl'
         check_password.return_value = True
         has_tags_modifications.return_value = False
@@ -68,17 +99,24 @@ class TestRabbitMQUserModule(ModuleTestCase):
 
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
-    def test_same_permissions_not_changing(self, has_tags_modifications, _get_permissions, _exec, get_bin_path):
+    def test_same_permissions_not_changing(self,
+                                           has_tags_modifications,
+                                           _get_permissions,
+                                           _check_version,
+                                           _exec,
+                                           get_bin_path):
         set_module_args({
             'user': 'someuser',
             'password': 'somepassword',
             'state': 'present',
             'permissions': [{'vhost': '/', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'}],
         })
-        _get_permissions.return_value = [{'vhost': '/', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'}]
-        _exec.return_value = ['someuser\t[]']
+        _get_permissions.return_value = {'/': {'read': '.*', 'write': '.*', 'configure': '.*', 'vhost': '/'}}
+        _exec.return_value = 'someuser\t[]'
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
         get_bin_path.return_value = '/rabbitmqctl'
         has_tags_modifications.return_value = False
         try:
@@ -87,51 +125,232 @@ class TestRabbitMQUserModule(ModuleTestCase):
             self._assert(e, 'changed', False)
             self._assert(e, 'state', 'present')
 
-    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
-    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
-    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
-    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.set_permissions')
-    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
-    def test_permissions_are_fixed(self, has_tags_modifications, set_permissions, _get_permissions, _exec, get_bin_path):
-        set_module_args({
-            'user': 'someuser',
-            'password': 'somepassword',
-            'state': 'present',
-            'permissions': [{'vhost': '/', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'}],
-        })
-        set_permissions.return_value = None
-        _get_permissions.return_value = []
-        _exec.return_value = ['someuser\t[]']
-        get_bin_path.return_value = '/rabbitmqctl'
-        has_tags_modifications.return_value = False
-        try:
-            self.module.main()
-        except AnsibleExitJson as e:
-            self._assert(e, 'changed', True)
-            self._assert(e, 'state', 'present')
-            assert set_permissions.call_count == 1
+    @patch('ansible.module_utils.basic.AnsibleModule')
+    def test_status_can_be_parsed(self, module):
+        """Test correct parsing of the output of the status command."""
+        module.get_bin_path.return_value = '/rabbitmqctl'
+        module.check_mode = False
+
+        versions = ['3.6.10', '3.6.16']
+        for version_num in versions:
+            def side_effect(args):
+                assert '-q' in args
+                if '--formatter' in args:
+                    return 64, '', ''
+                return 0, rabbitmq_3_6_status.replace('version_num', version_num), ''
+
+            module.run_command.side_effect = side_effect
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            self.assertEqual(len(module.run_command.call_args_list), 2)
+            last_call_args = flatten(module.run_command.call_args_list[-1][0])
+            self.assertTrue('-q' in last_call_args)
+            self.assertTrue('--formatter' not in last_call_args)
+            self.assertEqual(user_controller._version, distutils.version.StrictVersion(version_num))
+            module.run_command.reset_mock()
+
+        versions = ['3.7.6', '3.7.7', '3.7.8', '3.7.9', '3.7.10', '3.7.11', '3.7.12', '3.7.13', '3.7.14', '3.7.15',
+                    '3.7.16', '3.7.17', '3.7.18', '3.7.19', '3.7.20', '3.7.21', '3.7.22', '3.7.23']
+        for version_num in versions:
+            def side_effect(args):
+                self.assertTrue('-q' in args)
+                self.assertTrue('--formatter' in args)
+                self.assertTrue('json' in args)
+                return 0, rabbitmq_3_7_status.replace('version_num', str([ord(c) for c in version_num])), ''
+
+            module.run_command.side_effect = side_effect
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            self.assertEqual(1, module.run_command.call_count)
+            self.assertEqual(user_controller._version, distutils.version.StrictVersion(version_num))
+            module.run_command.reset_mock()
+
+        versions = ['3.8.0', '3.8.1', '3.8.2']
+        for version_num in versions:
+            def side_effect(args):
+                self.assertTrue('-q' in args)
+                self.assertTrue('--formatter' in args)
+                self.assertTrue('json' in args)
+                return 0, rabbitmq_3_8_status.replace('version_num', version_num), ''
+
+            module.run_command.side_effect = side_effect
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            self.assertEqual(1, module.run_command.call_count)
+            self.assertEqual(user_controller._version, distutils.version.StrictVersion(version_num))
+            module.run_command.reset_mock()
 
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
-    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.set_permissions')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
-    def test_permissions_are_fixed_with_different_host(self, has_tags_modifications, set_permissions, _get_permissions,
-                                                       _exec, get_bin_path):
+    def test_permissions_are_fixed(self,
+                                   has_tags_modifications,
+                                   _get_permissions,
+                                   _check_version,
+                                   _exec,
+                                   get_bin_path):
+        """Test changes in permissions are fixed.
+
+        Ensure that permissions that do not need to be changed are not, permissions with differences are
+        fixed and permissions are cleared when needed, with the minimum number of operations. The
+        permissions are fed into the module using the pre-3.7 version format.
+        """
         set_module_args({
             'user': 'someuser',
             'password': 'somepassword',
             'state': 'present',
-            'permissions': [{'vhost': '/', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'}],
+            'permissions': [
+                {'vhost': '/', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'},
+                {'vhost': '/ok', 'configure': '^$', 'write': '^$', 'read': '^$'}
+            ],
         })
-        set_permissions.return_value = None
-        _get_permissions.return_value = [{'vhost': 'monitoring', 'configure_priv': '.*', 'write_priv': '.*', 'read_priv': '.*'}]
-        _exec.return_value = ['someuser\t[]']
         get_bin_path.return_value = '/rabbitmqctl'
         has_tags_modifications.return_value = False
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        _get_permissions.return_value = {
+            '/wrong_vhost': {'vhost': '/wrong_vhost', 'configure': '', 'write': '', 'read': ''},
+            '/ok': {'vhost': '/ok', 'configure': '^$', 'write': '^$', 'read': '^$'}
+        }
+
+        def side_effect(args):
+            if 'list_users' in args:
+                self.assertTrue('--formatter' not in args)
+                self.assertTrue('json' not in args)
+                return 'someuser\t[administrator, management]'
+            if 'clear_permissions' in args:
+                self.assertTrue('someuser' in args)
+                self.assertTrue('/wrong_vhost' in args)
+                return ''
+            if 'set_permissions' in args:
+                self.assertTrue('someuser' in args)
+                self.assertTrue('/' in args)
+                self.assertTrue(['.*', '.*', '.*'] == args[-3:])
+                return ''
+        _exec.side_effect = side_effect
+
         try:
             self.module.main()
         except AnsibleExitJson as e:
             self._assert(e, 'changed', True)
             self._assert(e, 'state', 'present')
-            assert set_permissions.call_count == 1
+            self.assertEqual(_exec.call_count, 3)
+            self.assertTrue(['clear_permissions', '-p', '/wrong_vhost', 'someuser'] ==
+                            flatten(_exec.call_args_list[-2][0]))
+            self.assertTrue(['set_permissions', '-p', '/', 'someuser', '.*', '.*', '.*'] ==
+                            flatten(_exec.call_args_list[-1][0]))
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
+    def test_tags_are_fixed(self, _get_permissions, _check_version, _exec, get_bin_path):
+        """Test user tags are fixed."""
+        set_module_args({
+            'user': 'someuser',
+            'password': 'somepassword',
+            'state': 'present',
+            'tags': 'tag1,tags2',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        _get_permissions.return_value = {'/': {'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}}
+
+        def side_effect(args):
+            if 'list_users' in args:
+                self.assertTrue('--formatter' not in args)
+                self.assertTrue('json' not in args)
+                return 'someuser\t[tag1, tag3]'
+            return ''
+        _exec.side_effect = side_effect
+
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+            self._assert(e, 'state', 'present')
+            self.assertEqual(_exec.call_count, 2)
+            self.assertTrue(lists_equal(['set_user_tags', 'someuser', 'tag1', 'tags2'],
+                                        flatten(_exec.call_args_list[-1][0])))
+
+    @patch('ansible.module_utils.basic.AnsibleModule')
+    def test_user_json_data_can_be_parsed(self, module):
+        """Ensure that user json data can be parsed.
+
+        From version 3.7 onwards `rabbitmqctl` can output the user data in proper json format. Check that parsing
+        works correctly.
+        """
+
+        def side_effect(args):
+            self.assertTrue('-q' in args)
+            self.assertTrue('--formatter' in args)
+            self.assertTrue('json' in args)
+            if 'status' in args:
+                return 0, rabbitmq_3_8_status.replace('version_num', '3.8.1'), ''
+            if 'list_users' in args:
+                return 0, '''[
+{"user":"someuser","tags":["administrator","management"]}
+]''', ''
+            if 'list_user_permissions' in args:
+                return 0, '''[
+{"vhost":"/test","configure":"^$","write":"^$","read":"^$"}
+,{"vhost":"/","configure":"^$","write":"^$","read":"^$"}
+]''', ''
+            return 100, '', ''
+
+        module.run_command.side_effect = side_effect
+        user_controller = rabbitmq_user.RabbitMqUser(
+            module, 'someuser', 'somepassword', list(),
+            [{'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}], 'rabbit',
+            bulk_permissions=True)
+        self.assertTrue(user_controller.get())
+        self.assertTrue(user_controller._version, distutils.version.StrictVersion('3.8.1'))
+        self.assertTrue(user_controller.existing_tags, ["administrator", "management"])
+        self.assertTrue(user_controller.existing_permissions == {
+            '/test': {'vhost': '/test', 'configure': '^$', 'write': '^$', 'read': '^$'},
+            '/': {'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}})
+        self.assertEqual(module.run_command.call_count, 3)
+
+    @patch('ansible.module_utils.basic.AnsibleModule')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    def test_non_bulk_permissions_are_parsed_and_set(self, _check_version, _exec, module):
+        """Test that non bulk permissions are parsed correctly.
+
+        Non-bulk permissions mean that only the permissions of the VHost specified will be changed if needed.
+        If the same user has permissions in other VHosts, these will not be modified.
+        """
+        module.get_bin_path.return_value = '/rabbitmqctl'
+        module.check_mode = False
+        _check_version.return_value = distutils.version.StrictVersion('3.8.0')
+
+        def side_effect(args):
+            self.assertTrue('--formatter' in args, args)
+            self.assertTrue('json' in args, args)
+            if 'list_users' in args:
+                return '''[
+{"user":"someuser","tags":["administrator","management"]}
+]'''
+            if 'list_user_permissions' in args:
+                self.assertTrue('someuser' in args, args)
+                return '''[
+{"vhost":"/test","configure":"^$","write":"^$","read":"^$"}
+,{"vhost":"/","configure":"^$","write":"^$","read":"^$"}
+]'''
+            raise Exception('wrong command: ' + str(args))
+
+        _exec.side_effect = side_effect
+        user_controller = rabbitmq_user.RabbitMqUser(
+            module, 'someuser', 'somepassword', list(), [{
+                'vhost': '/',
+                'configure_priv': '.*',
+                'write_priv': '.*',
+                'read_priv': '.*'
+            }], 'rabbit'
+        )
+        user_controller.get()
+
+        self.assertEqual(_exec.call_count, 2)
+        self.assertListEqual(list(user_controller.existing_permissions.keys()), ['/'])
+        self.assertEqual(user_controller.existing_permissions['/']['write'], '^$')
+        self.assertEqual(user_controller.existing_permissions['/']['read'], '^$')
+        self.assertEqual(user_controller.existing_permissions['/']['configure'], '^$')
+        self.assertTrue(user_controller.has_permissions_modifications())

--- a/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
+++ b/tests/unit/modules/messaging/rabbitmq/test_rabbitmq_user.py
@@ -17,9 +17,10 @@ else:
 from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
 from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 
-from ansible_collections.community.rabbitmq.tests.unit.modules.messaging.rabbitmq.rabbitmq_user_fixtures import (rabbitmq_3_6_status,
-                                                                     rabbitmq_3_7_status,
-                                                                     rabbitmq_3_8_status)
+from ansible_collections.community.rabbitmq.tests.unit.modules.messaging.rabbitmq.rabbitmq_user_fixtures import (
+    rabbitmq_3_6_status,
+    rabbitmq_3_7_status,
+    rabbitmq_3_8_status)
 
 
 def flatten(args):


### PR DESCRIPTION
Author: ptzianos

from https://github.com/ansible/ansible/pull/66876

##### SUMMARY

This PR is a refactoring of the RabbitMQ User module so that in the beginning of every operation it checks the version of the daemon and then, whenever possible, adds flags to the `rabbitmqctl` so that the output is a JSON document which can then be parsed in an easier and less "hacky" way. It is a more permanent solution relative [to this PR](https://github.com/ansible/ansible/pull/50381).
Specifically for versions 3.7 and newer of RabbitMQ, the `--formatter` flag is used to output JSON, while in versions before that, the `-q` flag is added to prevent unnecessary output to be printed and reduce parsing errors.
The `_exec` method has been refactored to allow the called to decide whether or not it wants an error to immediately cause the execution to stop, or if the error should be returned and handled on a higher level. This is done to allow the module the try to check for the version of the daemon in multiple different ways.
This has been tested with the following RabbitMQ versions:

    * 3.6.10

    * 3.6.16

    * 3.7.6

    * 3.7.6

    * 3.7.7

    * 3.7.8

    * 3.7.9

    * 3.7.10

    * 3.7.11

    * 3.7.12

    * 3.7.13

    * 3.7.14



##### SUMMARY

This PR is a refactoring of the RabbitMQ User module so that in the beginning of every operation it checks the version of the daemon and then, whenever possible, adds flags to the `rabbitmqctl` so that the output is a JSON document which can then be parsed in an easier and less "hacky" way. It is a more permanent solution relative [to this PR](https://github.com/ansible/ansible/pull/50381).
Specifically for versions 3.7 and newer of RabbitMQ, the `--formatter` flag is used to output JSON, while in versions before that, the `-q` flag is added to prevent unnecessary output to be printed and reduce parsing errors.
The `_exec` method has been refactored to allow the called to decide whether or not it wants an error to immediately cause the execution to stop, or if the error should be returned and handled on a higher level. This is done to allow the module the try to check for the version of the daemon in multiple different ways.
This has been tested with the following RabbitMQ versions:

    * 3.6.10

    * 3.6.16

    * 3.7.6

    * 3.7.6

    * 3.7.7

    * 3.7.8

    * 3.7.9

    * 3.7.10

    * 3.7.11

    * 3.7.12

    * 3.7.13

    * 3.7.14

    * 3.7.15

    * 3.7.16

    * 3.7.17

    * 3.7.18

    * 3.7.19

    * 3.7.20

    * 3.7.21

    * 3.7.22

    * 3.7.23

    * 3.8.0

    * 3.8.1

    * 3.8.2


All versions where deployed on an Ubuntu 18.04 Vagrant VM using an Ansible script. Samples of the command outputs have been added in the `rabbitmq_user_fixtures.py` file.
Tests have been expanded with output from the daemon process from various versions. Now tests cover both the behavior of the module but also the parsing of input.
A small issue has also been fixed, where the module is performing more operations than needed when changing the policies of a vhost. Specifically, if a user's policy is changing, then it was first deleted and then added again. In the current PR this is changed to only a single `set` operation that overwrites the previous policy.

Fixes #48890, addresses final part of #29281
##### ISSUE TYPE

    * Bugfix Pull Request


##### COMPONENT NAME

lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
##### ADDITIONAL INFORMATION

In 3.7.* versions of RabbitMQ, a weird issue was discovered, where `rabbitmqctl` would return unicode codes instead of the actual characters. This was fixed by checking the contents of the output and if they are integers to be converted into the unicode characters. No better way was found to solve this.
As mentioned previously, this was tested using Vagrant and two simple Ansible scripts:

`all_versions.yml`

```
---
- hosts: all
  vars:
  remote_user: vagrant
  tasks:
  - name: "Test RabbitMQ user module with server {{ item }}"
    include_tasks: rabbitmq.yml
    vars:
      rabbitmq_version: "{{ item.rabbitmq_version }}"
      erlang_verion: "{{ item.erlang_verion }}"
    with_items:
    - {"rabbitmq_version": "3.6.10-1", "erlang_verion": "19.x"}
    - {"rabbitmq_version": "3.6.16-2", "erlang_verion": "20.x"}
    - {"rabbitmq_version": "3.7.6-1", "erlang_verion": "20.x"}
    - {"rabbitmq_version": "3.7.7-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.8-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.9-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.10-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.11-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.12-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.13-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.14-1", "erlang_verion": "21.x"}
    - {"rabbitmq_version": "3.7.15-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.16-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.17-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.18-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.19-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.20-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.21-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.22-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.7.23-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.8.0-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.8.1-1", "erlang_verion": "22.x"}
    - {"rabbitmq_version": "3.8.2-1", "erlang_verion": "22.x"}
```

`rabbitmq.yml`

```yaml
---
- name: Add RabbitMQ keyserver
  apt_key:
    keyserver: hkps.pool.sks-keyservers.net
    id: "0x6B73A36E6026DFCA"
  become: yes
  become_user: root
  become_method: sudo
- name: Add trusted key of RabbitMQ repo
  apt_key:
    url: "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
    state: present
  become: yes
  become_user: root
  become_method: sudo
- name: Cleanup Erlang Debian repo
  file:
    path: /etc/apt/sources.list.d/erlang.list
    state: absent
  become: yes
  become_user: root
  become_method: sudo
- name: Add Erlang Debian repo
  apt_repository:
    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang-{{ erlang_verion }}"
    state: present
    filename: erlang
  become: yes
  become_user: root
  become_method: sudo
- name: Add RabbitMQ Debian repo
  apt_repository:
    repo: deb https://dl.bintray.com/rabbitmq/debian bionic main
    state: present
    filename: rabbitmq
  become: yes
  become_user: root
  become_method: sudo
- name: "Install RabbitMQ {{ rabbitmq_version }}"
  apt:
    name: "rabbitmq-server={{ rabbitmq_version }}"
    update_cache: yes
  become: yes
  become_user: root
  become_method: sudo
- name: Register RabbitMQ admins as root. Might cause changes
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator,management
    update_password: 'always'
  become: yes
  become_user: root
  become_method: sudo
- name: Register RabbitMQ admins as rabbitmq. No changes detected
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator,management
    update_password: 'always'
  become: yes
  become_user: rabbitmq
  become_method: sudo
- name: Register RabbitMQ admins as root. No changes detected
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator, management
    update_password: 'always'
  become: yes
  become_user: root
  become_method: sudo
- name: Change RabbitMQ admin tags. Changes detected
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator, management, bla
    update_password: 'always'
  become: yes
  become_user: root
  become_method: sudo
- name: Change RabbitMQ admin tags. Changes detected
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator, management
    update_password: 'always'
  become: yes
  become_user: root
  become_method: sudo
- name: Register RabbitMQ admins as vagrant which will fail
  rabbitmq_user:
    user: "guest"
    password: "guest2"
    state: present
    tags: administrator,management
    update_password: 'always'
  ignore_errors: yes
- name: Add a dummy user. Changes detected
  rabbitmq_user:
    user: "guest2"
    password: "guest2"
    state: present
  become: yes
  become_user: root
  become_method: sudo
- name: Delete dummy user. Changes detected
  rabbitmq_user:
    user: "guest2"
    state: absent
  become: yes
  become_user: root
  become_method: sudo
- name: Delete dummy user. No changes detected
  rabbitmq_user:
    user: "guest2"
    state: absent
  become: yes
  become_user: root
  become_method: sudo
- name: Ensure test vhost exists
  rabbitmq_vhost:
    name: /test
    state: present
  become: yes
  become_user: root
  become_method: sudo
- name: Fix dummy permissions to guest user. Changes detected
  rabbitmq_user:
    user: "guest"
    state: present
    tags: administrator,management
    permissions:
    - vhost: /
      configure_priv: ^$
      read_priv: ^$
      write_priv: ^$
    - vhost: /test
      configure_priv: ^$
      read_priv: ^pavlos-.*
      write_priv: ^$
  become: yes
  become_user: root
  become_method: sudo
- name: Add dummy permissions to guest user for test vhost. No changes detected
  rabbitmq_user:
    user: "guest"
    state: present
    tags: administrator,management
    vhost: /test
    configure_priv: ^$
    read_priv: ^pavlos-.*
    write_priv: ^$
  become: yes
  become_user: root
  become_method: sudo
- name: Fix dummy permissions to guest user. Changes detected
  rabbitmq_user:
    user: "guest"
    state: present
    tags: administrator,management
    permissions:
    - vhost: /
      configure_priv: ^$
      read_priv: ^$
      write_priv: ^$
    - vhost: /test
      configure_priv: ^$
      read_priv: ^$
      write_priv: ^$
  become: yes
  become_user: root
  become_method: sudo
```