### PR TITLE
rabbitmq_user: fix node argument parsing (#32)

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -382,7 +382,7 @@ def main():
         read_priv=dict(default='^$'),
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
+        node=dict(default='rabbit', type='bool'),
         update_password=dict(default='on_create', choices=['on_create', 'always'], no_log=False)
     )
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
Due to not passing `type='bool'` in `node` argument to  `AnsibleModule` it was parsed as `string` and `if` statement in line 264 always returned `true`. Fixes #32 

https://github.com/ansible-collections/community.rabbitmq/blob/981891b670476a00be6beae308f54da2c2b87ed8/plugins/modules/rabbitmq_user.py#L264-L265 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Like above
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
