### PR TITLE
rabbitmq_user: fix parsing of user output when no tags are associated

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -296,7 +296,11 @@ class RabbitMqUser(object):
                 return tags.replace('[', '').replace(']', '').replace(' ', '').strip('\t').split(',')
 
             users_and_tags = [user_entry.split('\t') for user_entry in users.strip().split('\n')]
-            users = dict([(user, process_tags(tags)) for user, tags in users_and_tags])
+
+            users = dict()
+            for user_entry in users_and_tags:
+                user_parts = user_entry.split('\t')
+                users[user_parts[0]] = process_tags(user_parts[1]) if len(user_parts) > 1 else []
 
         self.existing_tags = users.get(self.username, list())
         self.existing_permissions = self._get_permissions() if self.username in users else dict()


### PR DESCRIPTION
##### SUMMARY
When retrieving user and user tags and parsing the output into the RabbitMQUser class
an error occurs in Python 3.5 if the user is not associated with any user tags.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ADDITIONAL INFORMATION
From a fresh install of RabbitMQ and trying to delete the guest user fails under Python 3.5,
because it has no user tags associated with the user.

Ansible "code" that reproduces the error.
```yaml

- name: install rabbitmq
  apt:
    pkg: rabbitmq-server
    state: present
    install_recommends: no
  become: yes

- name: delete guest user
  rabbitmq_user:
    user: guest
    state: absent
  become: yes
```

Error this PR fixes.
```paste below
An exception occurred during task execution. To see the full traceback, use -vvv.
The error was: ValueError: not enough values to unpack (expected 2, got 1)
fatal: [default]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):
  File "<stdin>", line 102, in <module>
  File "<stdin>", line 94, in _ansiballz_main
  File "<stdin>", line 40, in invoke_module
  File "/usr/lib/python3.5/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_rabbitmq_user_payload_5njwqs12/ansible_rabbitmq_user_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_user.py", line 463, in <module>
  File "/tmp/ansible_rabbitmq_user_payload_5njwqs12/ansible_rabbitmq_user_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_user.py", line 431, in main
  File "/tmp/ansible_rabbitmq_user_payload_5njwqs12/ansible_rabbitmq_user_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_user.py", line 299, in get
  File "/tmp/ansible_rabbitmq_user_payload_5njwqs12/ansible_rabbitmq_user_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_user.py", line 299, in <listcomp>
ValueError: not enough values to unpack (expected 2, got 1)
", "module_stdout": "", "msg": "MODULE FAILURE
See stdout/stderr for the exact error", "rc": 1}
```