### PR TITLE
Cleanup rabbitmq queues

### DIFF
--- a/plugins/modules/rabbitmq_queue.py
+++ b/plugins/modules/rabbitmq_queue.py
@@ -15,7 +15,8 @@ author: Manuel Sousa (@manuel-sousa)
 
 short_description: Manage rabbitMQ queues
 description:
-  - This module uses rabbitMQ Rest API to create/delete queues
+  - This module uses rabbitMQ Rest API to create/delete queues.
+  - Due to limitations in the API, it cannot modify existing queues.
 requirements: [ "requests >= 1.0.0" ]
 options:
     name:
@@ -70,6 +71,8 @@ options:
     arguments:
         description:
             - extra arguments for queue. If defined this argument is a key/value dictionary
+            - Arguments here take precedence over parameters. If both are defined, the
+              argument will be used.
         type: dict
         default: {}
 extends_documentation_fragment:

--- a/plugins/modules/rabbitmq_queue.py
+++ b/plugins/modules/rabbitmq_queue.py
@@ -159,12 +159,12 @@ def main():
         )
 
     if module.params['state'] == 'present':
-        change_required = not queue_exists
+        add_or_delete_required = not queue_exists
     else:
-        change_required = queue_exists
+        add_or_delete_required = queue_exists
 
     # Check if attributes change on existing queue
-    if not change_required and r.status_code == 200 and module.params['state'] == 'present':
+    if not add_or_delete_required and r.status_code == 200 and module.params['state'] == 'present':
         if not (
             response['durable'] == module.params['durable'] and
             response['auto_delete'] == module.params['auto_delete'] and
@@ -214,13 +214,13 @@ def main():
 
     # Exit if check_mode
     if module.check_mode:
-        result['changed'] = change_required
+        result['changed'] = add_or_delete_required
         result['details'] = response
         result['arguments'] = module.params['arguments']
         module.exit_json(**result)
 
     # Do changes
-    if change_required:
+    if add_or_delete_required:
         if module.params['state'] == 'present':
             r = requests.put(
                 url,


### PR DESCRIPTION
##### SUMMARY
This PR combines a few commits that each clean up the `rabbitmq_queue` module. I'd be happy to split them out, but didn't want to spam with two-line PRs.

 * Adds some doc clarifications
 * Changes `change_required` to `add_or_delete_required` to more accurately reflect what it's doing
 * Modifies how the `arguments` property works.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
rabbitmq_queue

##### ADDITIONAL INFORMATION
More info in commit messages, but here's the gist:

    Previously, the module wrote out all of the checks to see if any of the
    properties of the queue had changed, evaluated them all at once, and
    only printed a generic failure method.
    
    Also, previously, specifying an option in the arguments dict would
    result in it being created, but the checks didn't catch it, so despite
    the options not changing, the check for changed attributes would cause
    the module to fail the second time it was run.
    
    This commit fixes both of those issues. Rather than synchronizing the
    module.params dict and the module.params['arguments'] dict after the
    checks are done, it does before, and it modifies the checks to be based
    off module.params['arguments'], which eventually becomes the final
    source of truth. This lets the checks run against
    module.params['arguments'] rather than module.params.
    
    This commit also extracts the check logic to a function, which describes
    what failed and why.
