### PR TITLE
Fix for parsing of global parameters, add integration and unit tests

### DIFF
--- a/plugins/modules/rabbitmq_global_parameter.py
+++ b/plugins/modules/rabbitmq_global_parameter.py
@@ -88,10 +88,13 @@ class RabbitMqGlobalParameter(object):
         return list()
 
     def get(self):
-        global_parameters = self._exec(['list_global_parameters'], True)
+        global_parameters = [param for param in self._exec(['list_global_parameters'], True) if param.strip()]
 
-        for param_item in global_parameters:
+        for idx, param_item in enumerate(global_parameters):
             name, value = param_item.split('\t')
+            # RabbitMQ 3.8.x and above return table header, ignore it
+            if idx == 0 and name == 'name' and value == 'value':
+                continue
 
             if name == self.name:
                 self._value = json.loads(value)

--- a/plugins/modules/rabbitmq_global_parameter.py
+++ b/plugins/modules/rabbitmq_global_parameter.py
@@ -37,7 +37,7 @@ options:
     default: rabbit
   state:
     description:
-      - Specify if user is to be added or removed
+      - Specify if global parameter is to be added or removed
     type: str
     required: false
     default: present

--- a/plugins/modules/rabbitmq_parameter.py
+++ b/plugins/modules/rabbitmq_parameter.py
@@ -42,7 +42,7 @@ options:
     default: rabbit
   state:
     description:
-      - Specify if user is to be added or removed
+      - Specify if parameter is to be added or removed
     type: str
     default: present
     choices: [ 'present', 'absent']

--- a/tests/integration/targets/rabbitmq_global_parameter/aliases
+++ b/tests/integration/targets/rabbitmq_global_parameter/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/rabbitmq_global_parameter/meta/main.yml
+++ b/tests/integration/targets/rabbitmq_global_parameter/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/tests/integration/targets/rabbitmq_global_parameter/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_global_parameter/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: tests.yml
+  when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/rabbitmq_global_parameter/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_global_parameter/tasks/tests.yml
@@ -1,0 +1,67 @@
+- block:
+  - set_fact:
+      parameter_name: cluster_name
+      parameter_value: "{{ 'integration-test' | to_json }}"
+
+  - name: Add global parameter
+    rabbitmq_global_parameter:
+      name: "{{ parameter_name }}"
+      value: "{{ parameter_value }}"
+      state: present
+    register: result
+
+  - name: Check that the global parameter was created successfuly
+    shell: "rabbitmqctl -q list_global_parameters | grep {{ parameter_name }}"
+    register: ctl_result
+
+  - name: Check that the global parameter is added
+    assert:
+      that:
+        - result is changed
+        - result is success
+
+  - name: Add global parameter (idempotency)
+    rabbitmq_global_parameter:
+      name: "{{ parameter_name }}"
+      value: "{{ parameter_value }}"
+      state: present
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Remove global parameter
+    rabbitmq_global_parameter:
+      name: "{{ parameter_name }}"
+      state: absent
+    register: result
+
+  - name: Get rabbitmqctl output
+    shell: "rabbitmqctl -q list_global_parameters | grep {{ parameter_name }}"
+    register: ctl_result
+    failed_when: ctl_result.rc == 0
+
+  - name: Check that the global parameter is removed
+    assert:
+      that:
+        - result is changed
+        - result is success
+
+  - name: Remove global parameter (idempotency)
+    rabbitmq_global_parameter:
+      name: "{{ parameter_name }}"
+      state: absent
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  always:
+    - name: Remove global parameter
+      rabbitmq_global_parameter:
+        name: "{{ parameter_name }}"
+        state: absent

--- a/tests/unit/modules/test_rabbitmq_global_parameter.py
+++ b/tests/unit/modules/test_rabbitmq_global_parameter.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.rabbitmq.plugins.modules import rabbitmq_global_parameter
+
+from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
+from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestRabbitMQGlobalParameterModule(ModuleTestCase):
+    def setUp(self):
+        super(TestRabbitMQGlobalParameterModule, self).setUp()
+        self.module = rabbitmq_global_parameter
+
+    def tearDown(self):
+        super(TestRabbitMQGlobalParameterModule, self).tearDown()
+
+    def _assert(self, exc, attribute, expected_value, msg=''):
+        value = exc.message[attribute] if hasattr(exc, attribute) else exc.args[0][attribute]
+        assert value == expected_value, msg
+
+    def test_without_required_parameters(self):
+        """Failure must occur when all parameters are missing."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_global_parameter.RabbitMqGlobalParameter._exec')
+    def test_read_without_initial_global_parameters(self, _exec, get_bin_path):
+        """Test that the code to read the global parameters does not fail anymore for RabbitMQ 3.7.x."""
+        set_module_args({
+            'name': 'cluster_name',
+            'state': 'absent',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        # command list_global_parameters returns:
+        # - RabbitMQ 3.6.x: ''
+        # - RabbitMQ 3.7.x: '\n'
+        # - RabbitMQ 3.8.x: 'name\tvalue\n' table header
+        for out in '', '\n', 'name\tvalue\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', False)
+                self._assert(e, 'state', 'absent')
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_global_parameter.RabbitMqGlobalParameter._exec')
+    def test_remove_global_parameter(self, _exec, get_bin_path):
+        """Test removal of global parameters."""
+        set_module_args({
+            'name': 'cluster_name',
+            'state': 'absent',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        # command list_global_parameters returns:
+        # - RabbitMQ 3.6.x: ''
+        # - RabbitMQ 3.7.x: '\n'
+        # - RabbitMQ 3.8.x: 'name\tvalue\n' table header
+        for out in 'cluster_name\t"rabbitmq-test"', 'cluster_name\t"rabbitmq-test"\n', 'name\tvalue\ncluster_name\t"rabbitmq-test"\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', True)
+                self._assert(e, 'state', 'absent')
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_global_parameter.RabbitMqGlobalParameter._exec')
+    def test_set_global_parameter(self, _exec, get_bin_path):
+        """Test setting of global parameters."""
+        set_module_args({
+            'name': 'cluster_name',
+            'value': '"rabbitmq-test"',
+            'state': 'present',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        versions = ['3.6', '3.7', '3.8']
+        for version_num in versions:
+            def side_effect(args, check_rc=True):
+                if 'list_global_parameters' in args:
+                    if version_num == '3.6':
+                        return 'other_param\t"other_value"\ncluster_name\t"another_name"'.splitlines()
+                    elif version_num == '3.7':
+                        return 'other_param\t"other_value"\ncluster_name\t"another_name"\n'.splitlines()
+                    else:
+                        return 'name\tvalue\nother_param\t"other_value"\ncluster_name\t"another_name"\n'.splitlines()
+                elif 'clear_global_parameter' in args or 'set_global_parameter' in args:
+                    return ''.splitlines()
+            _exec.side_effect = side_effect
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', True)
+                self._assert(e, 'state', 'present')
+                self._assert(e, 'value', 'rabbitmq-test')
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_global_parameter.RabbitMqGlobalParameter._exec')
+    def test_set_no_change_global_parameter(self, _exec, get_bin_path):
+        """Test that there is no change when setting the same global parameter."""
+        set_module_args({
+            'name': 'cluster_name',
+            'value': '"rabbitmq-test"',
+            'state': 'present',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        def side_effect(args, check_rc=True):
+            if 'list_global_parameters' in args:
+                return 'other_param\t"other_value"\ncluster_name\t"rabbitmq-test"'.splitlines()
+            elif 'clear_global_parameter' in args or 'set_global_parameter' in args:
+                return ''.splitlines()
+        _exec.side_effect = side_effect
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', False)
+            self._assert(e, 'state', 'present')
+            self._assert(e, 'value', 'rabbitmq-test')


### PR DESCRIPTION
##### SUMMARY
A set of patches to:
- fix the description of the state parameter in the docs of modules rabbitmq_global_parameter and rabbitmq_parameter
- improve parsing of the output of the list_global_parameters command when using RabbitMQ 3.7.x or newer
- add integration and unit tests for the rabbitmq_global_parameter module

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
rabbitmq_global_parameter
rabbitmq_parameter

##### ADDITIONAL INFORMATION
On RabbitMQ 3.7.x, when there are no global parameters set, the list_global_parameters command returns one empty line (an empty line followed by newline) and an exception is thrown when trying to split that line into the name, value pair:
```
# rabbitmqctl list_global_parameters -q -n rabbit

# ansible 127.0.0.1 -m rabbitmq_global_parameter -a 'name=cluster_name' -vvv
ansible 2.9.16
[...other output...]
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1610665097.78-28535-276852733488042/AnsiballZ_rabbitmq_global_parameter.py", line 102, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1610665097.78-28535-276852733488042/AnsiballZ_rabbitmq_global_parameter.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1610665097.78-28535-276852733488042/AnsiballZ_rabbitmq_global_parameter.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.messaging.rabbitmq.rabbitmq_global_parameter', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python2.7/runpy.py", line 176, in run_module
    fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
    mod_name, mod_fname, mod_loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/ansible_rabbitmq_global_parameter_payload_cubbWr/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 157, in <module>
  File "/tmp/ansible_rabbitmq_global_parameter_payload_cubbWr/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 137, in main
  File "/tmp/ansible_rabbitmq_global_parameter_payload_cubbWr/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 96, in get
ValueError: need more than 1 value to unpack
```

After the change:
```
# rabbitmqctl list_global_parameters -q -n rabbit

# ansible 127.0.0.1 -m rabbitmq_global_parameter -a 'name=cluster_name state=absent'
127.0.0.1 | SUCCESS => {
    "changed": false, 
    "name": "cluster_name", 
    "state": "absent", 
    "value": null
}
```


On RabbitMQ 3.8.x the list_global_parameters command returns a header before the list of parameters. The command supports a new optional argument, --no-table-headers, to not give that header:
```
# rabbitmqctl list_global_parameters -q -n rabbit 
name    value
internal_cluster_id     "rabbitmq-cluster-id-mG0W-uAoxG_nuY3tSPQfoQ"
# rabbitmqctl list_global_parameters -q -n rabbit --no-table-headers
internal_cluster_id     "rabbitmq-cluster-id-mG0W-uAoxG_nuY3tSPQfoQ"
```

If the module is asked to change the global parameter named 'name', then it fails:
```
# ansible 127.0.0.1 -m rabbitmq_global_parameter -a 'name=name state=absent' -vvv
ansible 2.9.16
[...other output...]
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1610666065.42-687-117915952511767/AnsiballZ_rabbitmq_global_parameter.py", line 102, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1610666065.42-687-117915952511767/AnsiballZ_rabbitmq_global_parameter.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1610666065.42-687-117915952511767/AnsiballZ_rabbitmq_global_parameter.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.messaging.rabbitmq.rabbitmq_global_parameter', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python2.7/runpy.py", line 176, in run_module
    fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 82, in _run_module_code
    mod_name, mod_fname, mod_loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/ansible_rabbitmq_global_parameter_payload_1A6b9_/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 157, in <module>
  File "/tmp/ansible_rabbitmq_global_parameter_payload_1A6b9_/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 137, in main
  File "/tmp/ansible_rabbitmq_global_parameter_payload_1A6b9_/ansible_rabbitmq_global_parameter_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_global_parameter.py", line 99, in get
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

I've thought that it is simpler to detect the header and ignore it compared to checking the RabbitMQ version and add the -no-table-headers argument to the command. Is this ok?

After the change:
```
# rabbitmqctl list_global_parameters -q -n rabbit
name    value
internal_cluster_id     "rabbitmq-cluster-id-i1i4cAi9aDWPMGi_eaPM0A"
# ansible 127.0.0.1 -m rabbitmq_global_parameter -a 'name=name state=absent'
127.0.0.1 | SUCCESS => {
    "changed": false, 
    "name": "name", 
    "state": "absent", 
    "value": null
}
```
