### PR TITLE
Added x-delayed-message as a valid exchange type

### DIFF
--- a/plugins/modules/rabbitmq_exchange.py
+++ b/plugins/modules/rabbitmq_exchange.py
@@ -41,7 +41,7 @@ options:
             - type for the exchange
         type: str
         required: false
-        choices: [ "fanout", "direct", "headers", "topic" ]
+        choices: [ "fanout", "direct", "headers", "topic", "x-delayed-message" ]
         aliases: [ "type" ]
         default: direct
     auto_delete:
@@ -106,7 +106,7 @@ def main():
             auto_delete=dict(default=False, type='bool'),
             internal=dict(default=False, type='bool'),
             exchange_type=dict(default='direct', aliases=['type'],
-                               choices=['fanout', 'direct', 'headers', 'topic'],
+                               choices=['fanout', 'direct', 'headers', 'topic', 'x-delayed-message'],
                                type='str'),
             arguments=dict(default=dict(), type='dict')
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The rabbitmq_exchange module should not accept the x-delayed-message type. Fixes #54.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_exchange
