### PR TITLE
Fix rabbitmq_policy tags json.loads

### DIFF
--- a/plugins/modules/rabbitmq_policy.py
+++ b/plugins/modules/rabbitmq_policy.py
@@ -195,7 +195,7 @@ class RabbitMqPolicy(object):
         policy_name = policy_data[name_fno]
         apply_to = policy_data[apply_to_fno]
         pattern = policy_data[pattern_fno].replace('\\\\', '\\')
-        tags = json.loads(policy_data[tags_fno])
+        tags = policy_data[tags_fno]
         priority = policy_data[priority_fno]
 
         return (policy_name == self._name and apply_to == self._apply_to

--- a/tests/integration/targets/rabbitmq_policy/aliases
+++ b/tests/integration/targets/rabbitmq_policy/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/rabbitmq_policy/meta/main.yml
+++ b/tests/integration/targets/rabbitmq_policy/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/tests/integration/targets/rabbitmq_policy/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_policy/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: tests.yml
+  when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
@@ -1,6 +1,6 @@
 - block:
   - set_fact:
-      vhost_name: /test
+      vhost_name: /policytest
       ha_policy_name: HA
 
   - name: Add host
@@ -18,7 +18,7 @@
       that:
         - result is changed
         - result is success
-        - '"false" in ctl_result.stdout'  # value for tracing, false is disabled
+        - '"false" in ctl_result.stdout'
 
   - name: Add host (idempotency)
     rabbitmq_vhost:

--- a/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
@@ -1,0 +1,91 @@
+- block:
+  - set_fact:
+      vhost_name: /hatest
+
+  - name: Add host
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+    register: result
+
+  - name: Check that the host was created successfuly
+    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+    register: ctl_result
+
+  - name: Check that the host is added
+    assert:
+      that:
+        - result is changed
+        - result is success
+        - '"false" in ctl_result.stdout'  # value for tracing, false is disabled
+
+  - name: Add host (idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Add an HA Policy
+    rabbitmq_policy:
+      name: HA
+      apply_to: queues
+      pattern: ".*"
+      tags:
+        ha-mode: all
+        ha-sync-mode: automatic
+        ha-sync-batch-size: 10000
+      vhost: "{{ vhost_name }}"
+    register: add_policy
+
+  - name: Check that the policy is added
+    assert:
+      that:
+        - add_policy is changed
+        - add_policy is success
+
+  - name: Add an HA Policy (idempotency)
+    rabbitmq_policy:
+      name: HA
+      apply_to: queues
+      pattern: ".*"
+      tags:
+        ha-mode: all
+        ha-sync-mode: automatic
+        ha-sync-batch-size: 10000
+      vhost: "{{ vhost_name }}"
+    register: add_policy
+
+  - name: Check policy idempotency
+    assert:
+      that:
+        - add_policy is not changed
+ 
+  - name: Remove the HA policy
+    rabbitmq_policy:
+      name: HA
+      state: absent
+      vhost: "{{ vhost_name }}"
+    register: remove_policy
+
+  - name: Check that the policy is removed
+    assert:
+      that:
+        - remove_policy is changed
+        - remove_policy is success
+
+  - name: Remove the HA Policy (idempotency)
+    rabbitmq_policy:
+      name: HA
+      state: absent
+      vhost: "{{ vhost_name }}"
+    register: remove_policy
+
+  - name: Check that the policy is removed (idempotency)
+    assert:
+      that:
+        - remove_policy is not changed

--- a/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
@@ -1,6 +1,7 @@
 - block:
   - set_fact:
-      vhost_name: /hatest
+      vhost_name: /test
+      ha_policy_name: HA
 
   - name: Add host
     rabbitmq_vhost:
@@ -32,7 +33,7 @@
 
   - name: Add an HA Policy
     rabbitmq_policy:
-      name: HA
+      name: "{{ ha_policy_name }}"
       apply_to: queues
       pattern: ".*"
       tags:
@@ -50,7 +51,7 @@
 
   - name: Add an HA Policy (idempotency)
     rabbitmq_policy:
-      name: HA
+      name: "{{ ha_policy_name }}"
       apply_to: queues
       pattern: ".*"
       tags:
@@ -67,7 +68,7 @@
  
   - name: Remove the HA policy
     rabbitmq_policy:
-      name: HA
+      name: "{{ ha_policy_name }}"
       state: absent
       vhost: "{{ vhost_name }}"
     register: remove_policy
@@ -80,7 +81,7 @@
 
   - name: Remove the HA Policy (idempotency)
     rabbitmq_policy:
-      name: HA
+      name: "{{ ha_policy_name }}"
       state: absent
       vhost: "{{ vhost_name }}"
     register: remove_policy


### PR DESCRIPTION
##### SUMMARY
Fixes #28 by removing the json.loads piece of `tags =` in `_policy_check`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`rabbitmq_policy`

##### ADDITIONAL INFORMATION
During the `_policy_check` piece of this module, `policy_data` is basically a list based on a split of the variable `policy`. However, `policy` does not contain data. As a result of the split, it becomes: 

`['vhost', 'name', 'pattern', 'apply-to', 'definition', 'priority']`

As there is no JSON data, there is no reason to use `json.loads` on a string.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce this issue:
1. Install the ansible collection using ansible-galaxy
2. Create a playbook with a set of tasks that deal with rabbitmq policies on a vhost. Example tasks below.

```
- name: Configure pubsub virtual host
  community.rabbitmq.rabbitmq_vhost:
    name: /pubsub
    state: present

- name: Configure an HA policy for pubsub
  community.rabbitmq.rabbitmq_policy:
    name: HA
    apply_to: queues
    pattern: ".*"
    tags:
      ha-mode: all
      ha-sync-mode: automatic
      ha-sync-batch-size: 10000
    vhost: /pubsub
```

3. Run the playbook

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# BEFORE
The full traceback is:
Traceback (most recent call last):
  File "/home/ansible/.ansible/tmp/ansible-tmp-1611654783.6917102-146428-116716834350778/AnsiballZ_rabbitmq_policy.py", line 102, in <module>
    _ansiballz_main()
  File "/home/ansible/.ansible/tmp/ansible-tmp-1611654783.6917102-146428-116716834350778/AnsiballZ_rabbitmq_policy.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/ansible/.ansible/tmp/ansible-tmp-1611654783.6917102-146428-116716834350778/AnsiballZ_rabbitmq_policy.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_policy', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.rabbitmq.rabbitmq_policy_payload__4toqeqo/ansible_community.rabbitmq.rabbitmq_policy_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_policy.py", line 248, in <module>
  File "/tmp/ansible_community.rabbitmq.rabbitmq_policy_payload__4toqeqo/ansible_community.rabbitmq.rabbitmq_policy_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_policy.py", line 237, in main
  File "/tmp/ansible_community.rabbitmq.rabbitmq_policy_payload__4toqeqo/ansible_community.rabbitmq.rabbitmq_policy_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_policy.py", line 161, in has_modifications
  File "/tmp/ansible_community.rabbitmq.rabbitmq_policy_payload__4toqeqo/ansible_community.rabbitmq.rabbitmq_policy_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_policy.py", line 161, in <genexpr>
  File "/tmp/ansible_community.rabbitmq.rabbitmq_policy_payload__4toqeqo/ansible_community.rabbitmq.rabbitmq_policy_payload.zip/ansible_collections/community/rabbitmq/plugins/modules/rabbitmq_policy.py", line 198, in _policy_check
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

#AFTER
TASK [rockylinux.rabbitmq : Configure the HA policy for pubsub] *********************************************
changed: [rabbitmq001.example.com]
```
