### PR TITLE
Use official rabbitmq-erlang repo

### DIFF
--- a/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -25,7 +25,7 @@
 
 - name: Add RabbitMQ Erlang repository
   apt_repository:
-    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang-20.x"
+    repo: ppa:rabbitmq/rabbitmq-erlang
     filename: 'rabbitmq-erlang'
     state: present
     update_cache: yes
@@ -37,7 +37,7 @@
 
 - name: Install RabbitMQ Server
   apt:
-    deb: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.7.14-1_all.deb
+    deb: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.8.14-1_all.deb
 
 - name: Install RabbitMQ TLS dependencies
   apt:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
JFrog is [shutting down bintray on May 1](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Switch to using the official PPA for `rabbitmq-erlang`. This also meant the version of RabbitMQ needed to be updated.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Tests Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`tests/integration/targets/setup_rabbitmq`