### PR TITLE
Support topic authorization

### DIFF
--- a/changelogs/fragments/73-topic-authorization.yml
+++ b/changelogs/fragments/73-topic-authorization.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rabbitmq_user - add support for `topic authorization <https://www.rabbitmq.com/access-control.html#topic-authorisation>`_ (featured in RabbitMQ 3.7.0).
+  - rabbitmq_user - add support for `topic authorization <https://www.rabbitmq.com/access-control.html#topic-authorisation>`_ (featured in RabbitMQ 3.7.0) (https://github.com/ansible-collections/community.rabbitmq/pull/73).

--- a/changelogs/fragments/73-topic-authorization.yml
+++ b/changelogs/fragments/73-topic-authorization.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_user - add support for `topic authorization <https://www.rabbitmq.com/access-control.html#topic-authorisation>`_ (featured in RabbitMQ 3.7.0).

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -77,6 +77,13 @@ options:
       - This option will be ignored when permissions option is used.
     type: str
     default: '^$'
+  topic_permissions:
+    description:
+      - a list of dicts, each dict contains vhost, exchange, read_priv and write_priv,
+        and represents a topic permission rule for that vhost.
+    type: list
+    elements: dict
+    default: []
   force:
     description:
       - Deletes and recreates the user.
@@ -120,6 +127,18 @@ EXAMPLES = '''
         read_priv: .*
         write_priv: .*
     state: present
+
+# Add user to server and assign some topic permissions on / vhost.
+# The user doesn't have topic permission rules for other vhosts
+- community.rabbitmq.rabbitmq_user:
+    user: joe
+    password: changeme
+    topic_permissions:
+      - vhost: /
+        exchange: amq.topic
+        read_priv: .*
+        write_priv: 'prod\.logging\..*'
+    state: present
 '''
 
 import distutils.version
@@ -154,6 +173,11 @@ def as_permission_dict(vhost_permission_list):
                  in normalized_permissions(vhost_permission_list)])
 
 
+def as_topic_permission_dict(topic_permission_list):
+    return dict([((perm['vhost'], perm['exchange']), perm) for perm
+                 in topic_permission_list])
+
+
 def only(vhost, vhost_permissions):
     return {vhost: vhost_permissions.get(vhost, {})}
 
@@ -164,17 +188,19 @@ def first(iterable):
 
 class RabbitMqUser(object):
     def __init__(self, module, username, password, tags, permissions,
-                 node, bulk_permissions=False):
+                 topic_permissions, node, bulk_permissions=False):
         self.module = module
         self.username = username
         self.password = password or ''
         self.node = node
         self.tags = list() if not tags else tags.replace(' ', '').split(',')
         self.permissions = as_permission_dict(permissions)
+        self.topic_permissions = as_topic_permission_dict(topic_permissions)
         self.bulk_permissions = bulk_permissions
 
         self.existing_tags = None
         self.existing_permissions = dict()
+        self.existing_topic_permissions = dict()
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
         self._version = self._check_version()
 
@@ -280,7 +306,8 @@ class RabbitMqUser(object):
     def get(self):
         """Retrieves the list of registered users from the node.
 
-        If the user is already present, the node will also be queried for the user's permissions.
+        If the user is already present, the node will also be queried for the user's permissions and topic
+        permissions.
         If the version of the node is >= 3.7.6 the JSON formatter will be used, otherwise the plaintext will be
         parsed.
         """
@@ -303,6 +330,7 @@ class RabbitMqUser(object):
 
         self.existing_tags = users.get(self.username, list())
         self.existing_permissions = self._get_permissions() if self.username in users else dict()
+        self.existing_topic_permissions = self._get_topic_permissions() if self.username in users else dict()
         return self.username in users
 
     def _get_permissions(self):
@@ -323,6 +351,20 @@ class RabbitMqUser(object):
             return as_permission_dict(permissions)
         else:
             return only(first(self.permissions.keys()), as_permission_dict(permissions))
+
+    def _get_topic_permissions(self):
+        """Get topic permissions of the user from RabbitMQ."""
+        if self._version < distutils.version.StrictVersion('3.7.0'):
+            return dict()
+        if self._version >= distutils.version.StrictVersion('3.7.6'):
+            permissions = json.loads(self._exec(['list_user_topic_permissions', self.username, '--formatter', 'json']))
+        else:
+            output = self._exec(['list_user_topic_permissions', self.username]).strip().split('\n')
+            perms_out = [perm.split('\t') for perm in output if perm.strip()]
+            permissions = list()
+            for vhost, exchange, write, read in perms_out:
+                permissions.append(dict(vhost=vhost, exchange=exchange, write=write, read=read))
+        return as_topic_permission_dict(permissions)
 
     def check_password(self):
         """Return `True` if the user can authenticate successfully."""
@@ -366,11 +408,36 @@ class RabbitMqUser(object):
             self._exec(cmd.split(' '))
         self.existing_permissions = self._get_permissions()
 
+    def set_topic_permissions(self):
+        permissions_to_add = list()
+        for vhost_exchange, permission_dict in self.topic_permissions.items():
+            if permission_dict != self.existing_topic_permissions.get(vhost_exchange, {}):
+                permissions_to_add.append(permission_dict)
+
+        permissions_to_clear = list()
+        for vhost_exchange in self.existing_topic_permissions.keys():
+            if vhost_exchange not in self.topic_permissions:
+                permissions_to_clear.append(vhost_exchange)
+
+        for vhost_exchange in permissions_to_clear:
+            vhost, exchange = vhost_exchange
+            cmd = ('clear_topic_permissions -p {vhost} {username} {exchange}'
+                   .format(username=self.username, vhost=vhost, exchange=exchange))
+            self._exec(cmd.split(' '))
+        for permissions in permissions_to_add:
+            cmd = ('set_topic_permissions -p {vhost} {username} {exchange} {write} {read}'
+                   .format(username=self.username, **permissions))
+            self._exec(cmd.split(' '))
+        self.existing_topic_permissions = self._get_topic_permissions()
+
     def has_tags_modifications(self):
         return set(self.tags) != set(self.existing_tags)
 
     def has_permissions_modifications(self):
         return self.existing_permissions != self.permissions
+
+    def has_topic_permissions_modifications(self):
+        return self.existing_topic_permissions != self.topic_permissions
 
 
 def main():
@@ -383,6 +450,7 @@ def main():
         configure_priv=dict(default='^$'),
         write_priv=dict(default='^$'),
         read_priv=dict(default='^$'),
+        topic_permissions=dict(default=list(), type='list', elements='dict'),
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         node=dict(default='rabbit'),
@@ -401,6 +469,7 @@ def main():
     configure_priv = module.params['configure_priv']
     write_priv = module.params['write_priv']
     read_priv = module.params['read_priv']
+    topic_permissions = module.params['topic_permissions']
     force = module.params['force']
     state = module.params['state']
     node = module.params['node']
@@ -422,13 +491,37 @@ def main():
         permissions.append(perm)
         bulk_permissions = False
 
+    if topic_permissions:
+        vhost_exchanges = [
+            (permission.get('vhost', '/'), permission.get('exchange'))
+            for permission in topic_permissions
+        ]
+        if any([ve_count > 1 for ve_count in count(vhost_exchanges).values()]):
+            module.fail_json(msg="Error parsing vhost topic_permissions: You can't "
+                                 "have two topic permission dicts for the same vhost "
+                                 "and the same exchange")
+
     for permission in permissions:
         if not permission['vhost']:
             module.fail_json(msg="Error parsing vhost permissions: You can't"
                                  "have an empty vhost when setting permissions")
 
+    for permission in topic_permissions:
+        if not permission['vhost']:
+            module.fail_json(msg="Error parsing vhost topic_permissions: You can't"
+                                 "have an empty vhost when setting topic permissions")
+        if not permission['exchange']:
+            module.fail_json(msg="Error parsing vhost topic_permissions: You can't"
+                                 "have an empty exchange when setting topic permissions")
+        # Normalize the arguments
+        for perm_name in ("read", "write"):
+            suffixed_perm_name = "{perm_name}_priv".format(perm_name=perm_name)
+            if suffixed_perm_name in permission:
+                permission[perm_name] = permission.pop(suffixed_perm_name)
+
     rabbitmq_user = RabbitMqUser(module, username, password, tags, permissions,
-                                 node, bulk_permissions=bulk_permissions)
+                                 topic_permissions, node,
+                                 bulk_permissions=bulk_permissions)
 
     result = dict(changed=False, user=username, state=state)
     if rabbitmq_user.get():
@@ -453,10 +546,15 @@ def main():
             if rabbitmq_user.has_permissions_modifications():
                 rabbitmq_user.set_permissions()
                 result['changed'] = True
+
+            if rabbitmq_user.has_topic_permissions_modifications():
+                rabbitmq_user.set_topic_permissions()
+                result['changed'] = True
     elif state == 'present':
         rabbitmq_user.add()
         rabbitmq_user.set_tags()
         rabbitmq_user.set_permissions()
+        rabbitmq_user.set_topic_permissions()
         result['changed'] = True
 
     module.exit_json(**result)

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -81,10 +81,13 @@ options:
     description:
       - A list of dicts, each dict contains vhost, exchange, read_priv and write_priv,
         and represents a topic permission rule for that vhost.
-      - By default vhost is / and exchange is amq.topic.
+      - By default vhost is C(/) and exchange is C(amq.topic).
+      - Supported since RabbitMQ 3.7.0. If RabbitMQ is older and topic_permissions are
+        set, the module will fail.
     type: list
     elements: dict
     default: []
+    version_added: '1.1.0'
   force:
     description:
       - Deletes and recreates the user.
@@ -106,7 +109,7 @@ options:
 '''
 
 EXAMPLES = '''
-# Add user to server and assign full access control on / vhost.
+# name: Add user to server and assign full access control on / vhost.
 # The user might have permission rules for other vhost but you don't care.
 - community.rabbitmq.rabbitmq_user:
     user: joe
@@ -117,7 +120,7 @@ EXAMPLES = '''
     write_priv: .*
     state: present
 
-# Add user to server and assign full access control on / vhost.
+# name: Add user to server and assign full access control on / vhost.
 # The user doesn't have permission rules for other vhosts
 - community.rabbitmq.rabbitmq_user:
     user: joe
@@ -129,7 +132,7 @@ EXAMPLES = '''
         write_priv: .*
     state: present
 
-# Add user to server and assign some topic permissions on / vhost.
+# name: Add user to server and assign some topic permissions on / vhost.
 # The user doesn't have topic permission rules for other vhosts
 - community.rabbitmq.rabbitmq_user:
     user: joe
@@ -138,7 +141,7 @@ EXAMPLES = '''
       - vhost: /
         exchange: amq.topic
         read_priv: .*
-        write_priv: 'prod\.logging\..*'
+        write_priv: 'prod\\.logging\\..*'
     state: present
 '''
 

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -79,8 +79,9 @@ options:
     default: '^$'
   topic_permissions:
     description:
-      - a list of dicts, each dict contains vhost, exchange, read_priv and write_priv,
+      - A list of dicts, each dict contains vhost, exchange, read_priv and write_priv,
         and represents a topic permission rule for that vhost.
+      - By default vhost is / and exchange is amq.topic.
     type: list
     elements: dict
     default: []
@@ -507,12 +508,8 @@ def main():
                                  "have an empty vhost when setting permissions")
 
     for permission in topic_permissions:
-        if not permission['vhost']:
-            module.fail_json(msg="Error parsing vhost topic_permissions: You can't"
-                                 "have an empty vhost when setting topic permissions")
-        if not permission['exchange']:
-            module.fail_json(msg="Error parsing vhost topic_permissions: You can't"
-                                 "have an empty exchange when setting topic permissions")
+        permission.setdefault('vhost', '/')
+        permission.setdefault('exchange', 'amq.topic')
         # Normalize the arguments
         for perm_name in ("read", "write"):
             suffixed_perm_name = "{perm_name}_priv".format(perm_name=perm_name)

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -87,7 +87,7 @@ options:
     type: list
     elements: dict
     default: []
-    version_added: '1.1.0'
+    version_added: '1.2.0'
   force:
     description:
       - Deletes and recreates the user.
@@ -481,7 +481,7 @@ def main():
 
     if permissions:
         vhosts = [permission.get('vhost', '/') for permission in permissions]
-        if any([vhost_count > 1 for vhost_count in count(vhosts).values()]):
+        if any(vhost_count > 1 for vhost_count in count(vhosts).values()):
             module.fail_json(msg="Error parsing vhost permissions: You can't "
                                  "have two permission dicts for the same vhost")
         bulk_permissions = True
@@ -500,7 +500,7 @@ def main():
             (permission.get('vhost', '/'), permission.get('exchange'))
             for permission in topic_permissions
         ]
-        if any([ve_count > 1 for ve_count in count(vhost_exchanges).values()]):
+        if any(ve_count > 1 for ve_count in count(vhost_exchanges).values()):
             module.fail_json(msg="Error parsing vhost topic_permissions: You can't "
                                  "have two topic permission dicts for the same vhost "
                                  "and the same exchange")

--- a/tests/integration/targets/rabbitmq_user/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests.yml
@@ -44,6 +44,42 @@
         that:
           - add_user.changed == false
 
+- name: Test change user topic permissions
+  block:
+    - name: Add user with topic permissions
+      rabbitmq_user:
+        user: joe
+        password: changeme
+        topic_permissions:
+          - vhost: /
+            exchange: amq.topic
+            read_priv: .*
+            write_priv: .*
+      register: add_user
+
+    - name: Check that changing topic permissions succeeds with a change
+      assert:
+        that:
+          - add_user.changed == true
+
+- name: Test change user topic permissions idempotence
+  block:
+    - name: Add user with topic permissions
+      rabbitmq_user:
+        user: joe
+        password: changeme
+        topic_permissions:
+          - vhost: /
+            exchange: amq.topic
+            read_priv: .*
+            write_priv: .*
+      register: add_user
+
+    - name: Check that changing topic permissions succeeds without a change
+      assert:
+        that:
+          - add_user.changed == false
+
 - name: Test add user tags
   block:
     - name: Add user with tags

--- a/tests/unit/modules/test_rabbitmq_user.py
+++ b/tests/unit/modules/test_rabbitmq_user.py
@@ -152,12 +152,12 @@ class TestRabbitMQUserModule(ModuleTestCase):
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
     def test_same_topic_permissions_not_changing(self,
-                                           has_tags_modifications,
-                                           _get_permissions,
-                                           _get_topic_permissions,
-                                           _check_version,
-                                           _exec,
-                                           get_bin_path):
+                                                 has_tags_modifications,
+                                                 _get_permissions,
+                                                 _get_topic_permissions,
+                                                 _check_version,
+                                                 _exec,
+                                                 get_bin_path):
         set_module_args({
             'user': 'someuser',
             'password': 'somepassword',
@@ -296,12 +296,12 @@ class TestRabbitMQUserModule(ModuleTestCase):
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
     def test_topic_permissions_are_fixed(self,
-                                   has_tags_modifications,
-                                   _get_permissions,
-                                   _get_topic_permissions,
-                                   _check_version,
-                                   _exec,
-                                   get_bin_path):
+                                         has_tags_modifications,
+                                         _get_permissions,
+                                         _get_topic_permissions,
+                                         _check_version,
+                                         _exec,
+                                         get_bin_path):
         """Test changes in topic permissions are fixed.
 
         Ensure that topic permissions that do not need to be changed are not, topic permissions with differences are
@@ -359,12 +359,12 @@ class TestRabbitMQUserModule(ModuleTestCase):
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
     def test_topic_permissions_defaults(self,
-                                   has_tags_modifications,
-                                   _get_permissions,
-                                   _get_topic_permissions,
-                                   _check_version,
-                                   _exec,
-                                   get_bin_path):
+                                        has_tags_modifications,
+                                        _get_permissions,
+                                        _get_topic_permissions,
+                                        _check_version,
+                                        _exec,
+                                        get_bin_path):
         """Test that the topic permissions defaults are set."""
         set_module_args({
             'user': 'someuser',

--- a/tests/unit/modules/test_rabbitmq_user.py
+++ b/tests/unit/modules/test_rabbitmq_user.py
@@ -68,6 +68,25 @@ class TestRabbitMQUserModule(ModuleTestCase):
                                    "permissions: You can't have two permission dicts for the same vhost")
 
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    def test_topic_permissions_with_same_vhost(self, _check_version, get_bin_path):
+        set_module_args({
+            'user': 'someuser',
+            'password': 'somepassword',
+            'state': 'present',
+            'topic_permissions': [{'vhost': '/', 'exchange': 'amq.topic'}, {'vhost': '/', 'exchange': 'amq.topic'}],
+        })
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        get_bin_path.return_value = '/rabbitmqctl'
+        try:
+            self.module.main()
+        except AnsibleFailJson as e:
+            self._assert(e, 'failed', True)
+            self._assert(e, 'msg', "Error parsing vhost topic_permissions: "
+                                   "You can't have two topic permission dicts for "
+                                   "the same vhost and the same exchange")
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.get')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.check_password')
@@ -126,6 +145,37 @@ class TestRabbitMQUserModule(ModuleTestCase):
             self._assert(e, 'changed', False)
             self._assert(e, 'state', 'present')
 
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_topic_permissions')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
+    def test_same_topic_permissions_not_changing(self,
+                                           has_tags_modifications,
+                                           _get_permissions,
+                                           _get_topic_permissions,
+                                           _check_version,
+                                           _exec,
+                                           get_bin_path):
+        set_module_args({
+            'user': 'someuser',
+            'password': 'somepassword',
+            'state': 'present',
+            'topic_permissions': [{'vhost': '/', 'exchange': 'amq.topic', 'write': '.*', 'read': '.*'}],
+        })
+        _get_permissions.return_value = {'/': {'configure': '^$', 'read': '^$', 'write': '^$', 'vhost': '/'}}
+        _get_topic_permissions.return_value = {('/', 'amq.topic'): {'read': '.*', 'write': '.*', 'vhost': '/', 'exchange': 'amq.topic'}}
+        _exec.return_value = 'someuser\t[]'
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        get_bin_path.return_value = '/rabbitmqctl'
+        has_tags_modifications.return_value = False
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', False)
+            self._assert(e, 'state', 'present')
+
     @patch('ansible.module_utils.basic.AnsibleModule')
     def test_status_can_be_parsed(self, module):
         """Test correct parsing of the output of the status command."""
@@ -141,7 +191,7 @@ class TestRabbitMQUserModule(ModuleTestCase):
                 return 0, rabbitmq_3_6_status.replace('version_num', version_num), ''
 
             module.run_command.side_effect = side_effect
-            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), list(), 'rabbit')
             self.assertEqual(len(module.run_command.call_args_list), 2)
             last_call_args = flatten(module.run_command.call_args_list[-1][0])
             self.assertTrue('-q' in last_call_args)
@@ -159,7 +209,7 @@ class TestRabbitMQUserModule(ModuleTestCase):
                 return 0, rabbitmq_3_7_status.replace('version_num', str([ord(c) for c in version_num])), ''
 
             module.run_command.side_effect = side_effect
-            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), list(), 'rabbit')
             self.assertEqual(1, module.run_command.call_count)
             self.assertEqual(user_controller._version, distutils.version.StrictVersion(version_num))
             module.run_command.reset_mock()
@@ -173,7 +223,7 @@ class TestRabbitMQUserModule(ModuleTestCase):
                 return 0, rabbitmq_3_8_status.replace('version_num', version_num), ''
 
             module.run_command.side_effect = side_effect
-            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), 'rabbit')
+            user_controller = rabbitmq_user.RabbitMqUser(module, 'someuser', 'somepassword', list(), list(), list(), 'rabbit')
             self.assertEqual(1, module.run_command.call_count)
             self.assertEqual(user_controller._version, distutils.version.StrictVersion(version_num))
             module.run_command.reset_mock()
@@ -242,6 +292,69 @@ class TestRabbitMQUserModule(ModuleTestCase):
     @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_topic_permissions')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser.has_tags_modifications')
+    def test_topic_permissions_are_fixed(self,
+                                   has_tags_modifications,
+                                   _get_permissions,
+                                   _get_topic_permissions,
+                                   _check_version,
+                                   _exec,
+                                   get_bin_path):
+        """Test changes in topic permissions are fixed.
+
+        Ensure that topic permissions that do not need to be changed are not, topic permissions with differences are
+        fixed and topic permissions are cleared when needed, with the minimum number of operations.
+        """
+        set_module_args({
+            'user': 'someuser',
+            'password': 'somepassword',
+            'state': 'present',
+            'topic_permissions': [
+                {'vhost': '/', 'exchange': 'amq.topic', 'write_priv': '.*', 'read_priv': '.*'},
+                {'vhost': '/ok', 'exchange': 'amq.topic', 'write': '^$', 'read': '^$'}
+            ],
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+        has_tags_modifications.return_value = False
+        _check_version.return_value = distutils.version.StrictVersion('3.6.10')
+        _get_permissions.return_value = {}
+        _get_topic_permissions.return_value = {
+            ('/wrong_vhost', 'amq.topic'): {'vhost': '/wrong_vhost', 'exchange': 'amq.topic', 'write': '', 'read': ''},
+            ('/ok', 'amq.topic'): {'vhost': '/ok', 'exchange': 'amq.topic', 'write': '^$', 'read': '^$'}
+        }
+
+        def side_effect(args):
+            if 'list_users' in args:
+                self.assertTrue('--formatter' not in args)
+                self.assertTrue('json' not in args)
+                return 'someuser\t[administrator, management]'
+            if 'clear_topic_permissions' in args:
+                self.assertTrue('someuser' in args)
+                self.assertTrue('/wrong_vhost' in args)
+                return ''
+            if 'set_topic_permissions' in args:
+                self.assertTrue('someuser' in args)
+                self.assertTrue('/' in args, args)
+                self.assertTrue(['amq.topic', '.*', '.*'] == args[-3:])
+                return ''
+        _exec.side_effect = side_effect
+
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+            self._assert(e, 'state', 'present')
+            self.assertEqual(_exec.call_count, 4)
+            self.assertTrue(['clear_topic_permissions', '-p', '/wrong_vhost', 'someuser', 'amq.topic'] ==
+                            flatten(_exec.call_args_list[-2][0]))
+            self.assertTrue(['set_topic_permissions', '-p', '/', 'someuser', 'amq.topic', '.*', '.*'] ==
+                            flatten(_exec.call_args_list[-1][0]))
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._check_version')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._get_permissions')
     def test_tags_are_fixed(self, _get_permissions, _check_version, _exec, get_bin_path):
         """Test user tags are fixed."""
@@ -295,20 +408,29 @@ class TestRabbitMQUserModule(ModuleTestCase):
 {"vhost":"/test","configure":"^$","write":"^$","read":"^$"}
 ,{"vhost":"/","configure":"^$","write":"^$","read":"^$"}
 ]''', ''
+            if 'list_user_topic_permissions' in args:
+                return 0, '''[
+{"vhost":"/test","exchange":"amq.topic","write":"^$","read":"^$"}
+,{"vhost":"/","exchange":"amq.topic","write":"^$","read":"^$"}
+]''', ''
             return 100, '', ''
 
         module.run_command.side_effect = side_effect
         user_controller = rabbitmq_user.RabbitMqUser(
             module, 'someuser', 'somepassword', list(),
-            [{'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}], 'rabbit',
-            bulk_permissions=True)
+            [{'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}],
+            [{'vhost': '/', 'exchange': 'amq.topic', 'write': '^$', 'read': '^$'}],
+            'rabbit', bulk_permissions=True)
         self.assertTrue(user_controller.get())
         self.assertTrue(user_controller._version, distutils.version.StrictVersion('3.8.1'))
         self.assertTrue(user_controller.existing_tags, ["administrator", "management"])
         self.assertTrue(user_controller.existing_permissions == {
             '/test': {'vhost': '/test', 'configure': '^$', 'write': '^$', 'read': '^$'},
             '/': {'vhost': '/', 'configure': '^$', 'write': '^$', 'read': '^$'}})
-        self.assertEqual(module.run_command.call_count, 3)
+        self.assertTrue(user_controller.existing_topic_permissions == {
+            ('/test', 'amq.topic'): {'vhost': '/test', 'exchange': 'amq.topic', 'write': '^$', 'read': '^$'},
+            ('/', 'amq.topic'): {'vhost': '/', 'exchange': 'amq.topic', 'write': '^$', 'read': '^$'}})
+        self.assertEqual(module.run_command.call_count, 4)
 
     @patch('ansible.module_utils.basic.AnsibleModule')
     @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_user.RabbitMqUser._exec')
@@ -336,6 +458,12 @@ class TestRabbitMQUserModule(ModuleTestCase):
 {"vhost":"/test","configure":"^$","write":"^$","read":"^$"}
 ,{"vhost":"/","configure":"^$","write":"^$","read":"^$"}
 ]'''
+            if 'list_user_topic_permissions' in args:
+                self.assertTrue('someuser' in args, args)
+                return '''[
+{"vhost":"/test","exchange":"amq.topic","write":"^$","read":"^$"}
+,{"vhost":"/","exchange":"amq.topic","write":"^$","read":"^$"}
+]'''
             raise Exception('wrong command: ' + str(args))
 
         _exec.side_effect = side_effect
@@ -345,11 +473,11 @@ class TestRabbitMQUserModule(ModuleTestCase):
                 'configure_priv': '.*',
                 'write_priv': '.*',
                 'read_priv': '.*'
-            }], 'rabbit'
+            }], [], 'rabbit'
         )
         user_controller.get()
 
-        self.assertEqual(_exec.call_count, 2)
+        self.assertEqual(_exec.call_count, 3)
         self.assertListEqual(list(user_controller.existing_permissions.keys()), ['/'])
         self.assertEqual(user_controller.existing_permissions['/']['write'], '^$')
         self.assertEqual(user_controller.existing_permissions['/']['read'], '^$')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add support for topic authorizations in the user module
    
[Topic authorization](https://www.rabbitmq.com/access-control.html#topic-authorisation) has been added in RabbitMQ 3.7.0.

Only the full topic permission list is supported for now, similar to the existing vhost permission list.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`rabbitmq_user`

##### ADDITIONAL INFORMATION

I think there may be places for code refactoring in this change, but not as much as one would think since the format is not identical, and we still want different error messages between vhost authorization and topic authorization.