### PR TITLE
Add module: rabbitmq_feature_flag

### DIFF
--- a/plugins/modules/rabbitmq_feature_flag.py
+++ b/plugins/modules/rabbitmq_feature_flag.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Damian Dabrowski <damian@dabrowski.cloud>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_feature_flag
+short_description: Enables feature flag
+description:
+  - Allows to enable specified feature flag
+author: "Damian Dabrowski (@damiandabrowski5)"
+options:
+  name:
+    description:
+      - Feature flag name
+    type: str
+    required: true
+  node:
+    description:
+      - erlang node name of the target rabbit node
+    type: str
+    required: false
+    default: rabbit
+'''
+
+EXAMPLES = '''
+# Enable the 'maintenance_mode_status' feature flag on 'rabbit@node-1'
+- community.rabbitmq.rabbitmq_feature_flag:
+    name: maintenance_mode_status 
+    node: rabbit@node-1
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+class RabbitMqFeatureFlag(object):
+    def __init__(self, module, name, node):
+        self.module = module
+        self.name = name
+        self.node = node
+        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self.state = self.get_flag_state()
+
+    def _exec(self, args, run_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
+            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
+            return out.splitlines()
+        return list()
+
+    def get_flag_state(self):
+        global_parameters = self._exec(['list_feature_flags'], True)
+
+        for param_item in global_parameters:
+            name, state = param_item.split('\t')
+            if name == self.name:
+                if state == 'enabled':
+                    return 'enabled'
+                return 'disabled'
+        return 'unavailable'
+
+    def enable(self):
+        self._exec(['enable_feature_flag', self.name])
+
+def main():
+    arg_spec = dict(
+        name=dict(type='str', required=True),
+        node=dict(type='str', default='rabbit')
+    )
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        supports_check_mode=True
+    )
+
+    name = module.params['name']
+    node = module.params['node']
+
+    result = dict(changed=False)
+    rabbitmq_feature_flag = RabbitMqFeatureFlag(module, name, node)
+
+    if rabbitmq_feature_flag.state == 'disabled':
+        rabbitmq_feature_flag.enable()
+        result['changed'] = True
+    if rabbitmq_feature_flag.state == 'unavailable':
+        module.fail_json(msg="%s feature flag is not available" % (name))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/rabbitmq_upgrade.py
+++ b/plugins/modules/rabbitmq_upgrade.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Damian Dabrowski <damian@dabrowski.cloud>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_upgrade
+short_description: Execute rabbitmq-upgrade commands
+description:
+  - Allows to execute rabbitmq-upgrade commands
+author: "Damian Dabrowski (@damiandabrowski5)"
+options:
+  action:
+    description:
+      - Specify action to be executed
+    type: str
+    required: true
+    choices: ['await_online_quorum_plus_one','await_online_synchronized_mirror','post_upgrade','drain','revive']
+  node:
+    description:
+      - erlang node name of the target rabbit node
+    type: str
+    required: false
+    default: rabbit
+'''
+
+EXAMPLES = '''
+# Drain 'rabbit@node-1' node(i.e. put it into maintenance mode)
+- community.rabbitmq.rabbitmq_upgrade:
+    action: drain
+    node: rabbit@node-1
+'''
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+
+class RabbitMqUpgrade(object):
+    def __init__(self, module, action, node, result):
+        self.module = module
+        self.action = action
+        self.node = node
+        self.result = result
+
+    def _exec(self, binary, args, run_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+            cmd = [self.module.get_bin_path(binary, True)]
+            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
+            return out.splitlines()
+        return list()
+
+    def is_node_under_maintenance(self):
+        cmd = self._exec('rabbitmq-diagnostics',
+                         ['--formatter', 'json', 'status', '-n', self.node], True)
+        node_status = json.loads("".join(cmd))
+        maint_enabled = node_status['is_under_maintenance']
+        if maint_enabled:
+            return True
+        return False
+
+    def is_maint_flag_enabled(self):
+        feature_flags = self._exec('rabbitmqctl', ['list_feature_flags', '-q'], True)
+        for param_item in feature_flags:
+            name, state = param_item.split('\t')
+            if name == 'maintenance_mode_status' and state == 'enabled':
+                return True
+        return False
+
+    def drain(self):
+        if not self.is_maint_flag_enabled():
+            self.module.fail_json(msg='maintenance_mode_status feature_flag is disabled.')
+        if not self.is_node_under_maintenance():
+            self._exec('rabbitmq-upgrade', ['drain', '-n', self.node])
+            self.result['changed'] = True
+
+    def revive(self):
+        if not self.is_maint_flag_enabled():
+            self.module.fail_json(msg='maintenance_mode_status feature_flag is disabled.')
+        if self.is_node_under_maintenance():
+            self._exec('rabbitmq-upgrade', ['revive', '-n', self.node])
+            self.result['changed'] = True
+
+    def await_online_quorum_plus_one(self):
+        self._exec('rabbitmq-upgrade', ['await_online_quorum_plus_one'])
+        self.result['changed'] = True
+
+    def await_online_synchronized_mirror(self):
+        self._exec('rabbitmq-upgrade', ['await_online_synchronized_mirror'])
+        self.result['changed'] = True
+
+    def post_upgrade(self):
+        self._exec('rabbitmq-upgrade', ['post_upgrade'])
+        self.result['changed'] = True
+
+def main():
+    arg_spec = dict(
+        action=dict(
+            choices=['await_online_quorum_plus_one', 'await_online_synchronized_mirror', 'post_upgrade', 'drain', 'revive'],
+            required=True),
+        node=dict(type='str', default='rabbit')
+    )
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        supports_check_mode=True
+    )
+
+    action = module.params['action']
+    node = module.params['node']
+    result = dict(changed=False)
+
+    rabbitmq_upgrade = RabbitMqUpgrade(module, action, node, result)
+
+    getattr(rabbitmq_upgrade, action)()
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/integration/targets/rabbitmq_feature_flag/aliases
+++ b/tests/integration/targets/rabbitmq_feature_flag/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/rabbitmq_feature_flag/meta/main.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/tests/integration/targets/rabbitmq_feature_flag/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: tests.yml
+  when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
@@ -1,0 +1,19 @@
+- block:
+  - set_fact:
+      parameter_name: maintenance_mode_status
+      parameter_node: rabbit
+
+  - name: Enable feature flag
+    rabbitmq_feature_flag:
+      name: "{{ parameter_name }}"
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check if feature_flag module was completed successfully
+    assert:
+      that:
+        - result is success
+
+  - name: Check if specified feature flag is enabled
+    shell: "rabbitmqctl -q list_feature_flags | grep {{ parameter_name }}"
+    register: ctl_result

--- a/tests/integration/targets/rabbitmq_upgrade/aliases
+++ b/tests/integration/targets/rabbitmq_upgrade/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/rabbitmq_upgrade/meta/main.yml
+++ b/tests/integration/targets/rabbitmq_upgrade/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/tests/integration/targets/rabbitmq_upgrade/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_upgrade/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: tests.yml
+  when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/rabbitmq_upgrade/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_upgrade/tasks/tests.yml
@@ -1,0 +1,91 @@
+- block:
+  - set_fact:
+      parameter_node: rabbit
+
+  - name: Drain node
+    rabbitmq_upgrade:
+      action: drain
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check if node was properly drained
+    assert:
+      that:
+        - result is success
+        - result is changed
+
+  - name: Ensure node is under maintenance
+    shell: "rabbitmq-diagnostics -n {{ parameter_node }} status | grep 'Is under maintenance?: true'"
+
+  - name: Drain node (idempotency)
+    rabbitmq_upgrade:
+      action: drain
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Revive node
+    rabbitmq_upgrade:
+      action: revive
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check if node was properly revived
+    assert:
+      that:
+        - result is success
+        - result is changed
+
+  - name: Ensure node is under maintenance
+    shell: "rabbitmq-diagnostics -n {{ parameter_node }} status | grep 'Is under maintenance?: false'"
+
+  - name: Revive node (idempotency)
+    rabbitmq_upgrade:
+      action: revive
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Execute await_online_quorum_plus_one
+    rabbitmq_upgrade:
+      action: await_online_quorum_plus_one
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check the result of await_online_quorum_plus_one
+    assert:
+      that:
+        - result is success
+        - result is changed
+
+  - name: Execute await_online_synchronized_mirror
+    rabbitmq_upgrade:
+      action: await_online_synchronized_mirror
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check the result of await_online_synchronized_mirror
+    assert:
+      that:
+        - result is success
+        - result is changed
+
+  - name: Execute post_upgrade
+    rabbitmq_upgrade:
+      action: post_upgrade
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check the result of post_upgrade
+    assert:
+      that:
+        - result is success
+        - result is changed

--- a/tests/unit/modules/test_rabbitmq_feature_flag.py
+++ b/tests/unit/modules/test_rabbitmq_feature_flag.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.rabbitmq.plugins.modules import rabbitmq_feature_flag
+
+from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
+from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestRabbitMQFeatureFlagModule(ModuleTestCase):
+    def setUp(self):
+        super(TestRabbitMQFeatureFlagModule, self).setUp()
+        self.module = rabbitmq_feature_flag
+
+    def tearDown(self):
+        super(TestRabbitMQFeatureFlagModule, self).tearDown()
+
+    def _assert(self, exc, attribute, expected_value, msg=''):
+        value = exc.message[attribute] if hasattr(exc, attribute) else exc.args[0][attribute]
+        assert value == expected_value, msg
+
+    def test_without_required_parameters(self):
+        """Failure must occur when all parameters are missing."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_feature_flag.RabbitMqFeatureFlag._exec')
+    def test_enable_feature_flag(self, _exec, get_bin_path):
+        """Test enabling feature flag."""
+        set_module_args({
+            'name': 'maintenance_mode_status',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        for out in 'name\tstate\nmaintenance_mode_status\tdisabled', 'name\tstate\nmaintenance_mode_status\tdisabled\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_feature_flag.RabbitMqFeatureFlag._exec')
+    def test_enable_no_change_feature_flag(self, _exec, get_bin_path):
+        """Test that there is no change when enabling feature flag which is already enabled"""
+        set_module_args({
+            'name': 'maintenance_mode_status',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        for out in 'name\tstate\nmaintenance_mode_status\tenabled', 'name\tstate\nmaintenance_mode_status\tenabled\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', False)
+

--- a/tests/unit/modules/test_rabbitmq_upgrade.py
+++ b/tests/unit/modules/test_rabbitmq_upgrade.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.rabbitmq.plugins.modules import rabbitmq_upgrade
+
+from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
+from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestRabbitMQUpgradeModule(ModuleTestCase):
+    def setUp(self):
+        super(TestRabbitMQUpgradeModule, self).setUp()
+        self.module = rabbitmq_upgrade
+
+    def tearDown(self):
+        super(TestRabbitMQUpgradeModule, self).tearDown()
+
+    def _assert(self, exc, attribute, expected_value, msg=''):
+        value = exc.message[attribute] if hasattr(exc, attribute) else exc.args[0][attribute]
+        assert value == expected_value, msg
+
+    def test_without_required_parameters(self):
+        """Failure must occur when all parameters are missing."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_without_maitenance_mode_status_feature_flag(self, _exec, get_bin_path):
+        """Failure must occur when maintenance_mode_status feature_flag is disabled/not available"""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({
+                'action': 'drain',
+                'node': 'rabbit@node-1',
+            })
+            get_bin_path.return_value = '/rabbitmqctl'
+        
+            def side_effect(*args, **kwargs):
+                if args[0] == 'rabbitmq-diagnostics':
+                    out = '{"active_plugins":["rabbitmq_management","amqp_client","rabbitmq_web_dispatch","cowboy","cowlib","rabbitmq_management_agent"],"is_under_maintenance":false}'
+                elif args[0] == 'rabbitmqctl':
+                    out = 'name\tstate\nmaintenance_mode_status\tdisabled'
+                else:
+                    out = ''
+                return out.splitlines()
+        
+            _exec.side_effect = side_effect
+            self.module.main()
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_drain_node(self, _exec, get_bin_path):
+        """Execute action: drain on active node"""
+        set_module_args({
+            'action': 'drain',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        def side_effect(*args, **kwargs):
+            if args[0] == 'rabbitmq-diagnostics':
+                out = '{"active_plugins":["rabbitmq_management","amqp_client","rabbitmq_web_dispatch","cowboy","cowlib","rabbitmq_management_agent"],"is_under_maintenance":false}'
+            elif args[0] == 'rabbitmqctl':
+                out = 'name\tstate\nmaintenance_mode_status\tenabled'
+            else:
+                out = ''
+            return out.splitlines()
+
+        _exec.side_effect = side_effect
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_no_change_drain_node(self, _exec, get_bin_path):
+        """Execute action: drain on already disabled node"""
+        set_module_args({
+            'action': 'drain',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        def side_effect(*args, **kwargs):
+            if args[0] == 'rabbitmq-diagnostics':
+                out = '{"active_plugins":["rabbitmq_management","amqp_client","rabbitmq_web_dispatch","cowboy","cowlib","rabbitmq_management_agent"],"is_under_maintenance":true}'
+            elif args[0] == 'rabbitmqctl':
+                out = 'name\tstate\nmaintenance_mode_status\tenabled'
+            else:
+                out = ''
+            return out.splitlines()
+
+        _exec.side_effect = side_effect
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', False)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_revive_node(self, _exec, get_bin_path):
+        """Execute action: revive on disabled node"""
+        set_module_args({
+            'action': 'revive',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        def side_effect(*args, **kwargs):
+            if args[0] == 'rabbitmq-diagnostics':
+                out = '{"active_plugins":["rabbitmq_management","amqp_client","rabbitmq_web_dispatch","cowboy","cowlib","rabbitmq_management_agent"],"is_under_maintenance":true}'
+            elif args[0] == 'rabbitmqctl':
+                out = 'name\tstate\nmaintenance_mode_status\tenabled'
+            else:
+                out = ''
+            return out.splitlines()
+
+        _exec.side_effect = side_effect
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_no_change_revive_node(self, _exec, get_bin_path):
+        """Execute action: revive on active node"""
+        set_module_args({
+            'action': 'revive',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        def side_effect(*args, **kwargs):
+            if args[0] == 'rabbitmq-diagnostics':
+                out = '{"active_plugins":["rabbitmq_management","amqp_client","rabbitmq_web_dispatch","cowboy","cowlib","rabbitmq_management_agent"],"is_under_maintenance":false}'
+            elif args[0] == 'rabbitmqctl':
+                out = 'name\tstate\nmaintenance_mode_status\tenabled'
+            else:
+                out = ''
+            return out.splitlines()
+
+        _exec.side_effect = side_effect
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', False)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_await_online_quorum_plus_one(self, _exec, get_bin_path):
+        """Execute action: await_online_quorum_plus_one"""
+        set_module_args({
+            'action': 'await_online_quorum_plus_one',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_await_online_synchronized_mirror(self, _exec, get_bin_path):
+        """Execute action: await_online_synchronized_mirror"""
+        set_module_args({
+            'action': 'await_online_synchronized_mirror',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_upgrade.RabbitMqUpgrade._exec')
+    def test_post_upgrade(self, _exec, get_bin_path):
+        """Execute action: post_upgrade"""
+        set_module_args({
+            'action': 'post_upgrade',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        try:
+            self.module.main()
+        except AnsibleExitJson as e:
+            self._assert(e, 'changed', True)
+
+


### PR DESCRIPTION
##### SUMMARY
module: rabbitmq_upgrade
short_description: Execute rabbitmq-upgrade commands
description: Allows to execute rabbitmq-upgrade commands
options:
- action:
    description: Specify action to be executed
    type: str
    required: true
    choices: ['await_online_quorum_plus_one','await_online_synchronized_mirror','post_upgrade','drain','revive']
- node:
    description: erlang node name of the target rabbit node
    type: str
    required: false
    default: rabbit

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
rabbitmq_feature_flag


