### PR TITLE
Add module: rabbitmq_feature_flag

### DIFF
--- a/plugins/modules/rabbitmq_feature_flag.py
+++ b/plugins/modules/rabbitmq_feature_flag.py
@@ -12,25 +12,25 @@ DOCUMENTATION = '''
 module: rabbitmq_feature_flag
 short_description: Enables feature flag
 description:
-  - Allows to enable specified feature flag
+  - Allows to enable specified feature flag.
 author: "Damian Dabrowski (@damiandabrowski5)"
+version_added: '1.1.0'
 options:
   name:
     description:
-      - Feature flag name
+      - Feature flag name.
     type: str
     required: true
   node:
     description:
-      - erlang node name of the target rabbit node
+      - Erlang node name of the target rabbit node.
     type: str
-    required: false
     default: rabbit
 '''
 
 EXAMPLES = '''
-# Enable the 'maintenance_mode_status' feature flag on 'rabbit@node-1'
-- community.rabbitmq.rabbitmq_feature_flag:
+- name: Enable the 'maintenance_mode_status' feature flag on 'rabbit@node-1'
+  community.rabbitmq.rabbitmq_feature_flag:
     name: maintenance_mode_status
     node: rabbit@node-1
 '''

--- a/plugins/modules/rabbitmq_feature_flag.py
+++ b/plugins/modules/rabbitmq_feature_flag.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Damian Dabrowski <damian@dabrowski.cloud>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: rabbitmq_feature_flag
+short_description: Enables feature flag
+description:
+  - Allows to enable specified feature flag
+author: "Damian Dabrowski (@damiandabrowski5)"
+options:
+  name:
+    description:
+      - Feature flag name
+    type: str
+    required: true
+  node:
+    description:
+      - erlang node name of the target rabbit node
+    type: str
+    required: false
+    default: rabbit
+'''
+
+EXAMPLES = '''
+# Enable the 'maintenance_mode_status' feature flag on 'rabbit@node-1'
+- community.rabbitmq.rabbitmq_feature_flag:
+    name: maintenance_mode_status 
+    node: rabbit@node-1
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+class RabbitMqFeatureFlag(object):
+    def __init__(self, module, name, node):
+        self.module = module
+        self.name = name
+        self.node = node
+        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self.state = self.get_flag_state()
+
+    def _exec(self, args, run_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
+            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
+            return out.splitlines()
+        return list()
+
+    def get_flag_state(self):
+        global_parameters = self._exec(['list_feature_flags'], True)
+
+        for param_item in global_parameters:
+            name, state = param_item.split('\t')
+            if name == self.name:
+                if state == 'enabled':
+                    return 'enabled'
+                return 'disabled'
+        return 'unavailable'
+
+    def enable(self):
+        self._exec(['enable_feature_flag', self.name])
+
+def main():
+    arg_spec = dict(
+        name=dict(type='str', required=True),
+        node=dict(type='str', default='rabbit')
+    )
+    module = AnsibleModule(
+        argument_spec=arg_spec,
+        supports_check_mode=True
+    )
+
+    name = module.params['name']
+    node = module.params['node']
+
+    result = dict(changed=False)
+    rabbitmq_feature_flag = RabbitMqFeatureFlag(module, name, node)
+
+    if rabbitmq_feature_flag.state == 'disabled':
+        rabbitmq_feature_flag.enable()
+        result['changed'] = True
+    if rabbitmq_feature_flag.state == 'unavailable':
+        module.fail_json(msg="%s feature flag is not available" % (name))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/rabbitmq_feature_flag.py
+++ b/plugins/modules/rabbitmq_feature_flag.py
@@ -31,13 +31,15 @@ options:
 EXAMPLES = '''
 # Enable the 'maintenance_mode_status' feature flag on 'rabbit@node-1'
 - community.rabbitmq.rabbitmq_feature_flag:
-    name: maintenance_mode_status 
+    name: maintenance_mode_status
     node: rabbit@node-1
 '''
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 class RabbitMqFeatureFlag(object):
+
     def __init__(self, module, name, node):
         self.module = module
         self.name = name
@@ -66,6 +68,7 @@ class RabbitMqFeatureFlag(object):
     def enable(self):
         self._exec(['enable_feature_flag', self.name])
 
+
 def main():
     arg_spec = dict(
         name=dict(type='str', required=True),
@@ -90,6 +93,6 @@ def main():
 
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/tests/integration/targets/rabbitmq_feature_flag/aliases
+++ b/tests/integration/targets/rabbitmq_feature_flag/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/rhel

--- a/tests/integration/targets/rabbitmq_feature_flag/meta/main.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_rabbitmq

--- a/tests/integration/targets/rabbitmq_feature_flag/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: tests.yml
+  when: ansible_distribution == 'Ubuntu'

--- a/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
@@ -1,0 +1,19 @@
+- block:
+  - set_fact:
+      parameter_name: maintenance_mode_status
+      parameter_node: rabbit
+
+  - name: Enable feature flag
+    rabbitmq_feature_flag:
+      name: "{{ parameter_name }}"
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Check if feature_flag module was completed successfully
+    assert:
+      that:
+        - result is success
+
+  - name: Check if specified feature flag is enabled
+    shell: "rabbitmqctl -q list_feature_flags | grep {{ parameter_name }}"
+    register: ctl_result

--- a/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_feature_flag/tasks/tests.yml
@@ -3,6 +3,18 @@
       parameter_name: maintenance_mode_status
       parameter_node: rabbit
 
+  - name: Enable feature flag (check_mode)
+    rabbitmq_feature_flag:
+      name: "{{ parameter_name }}"
+      node: "{{ parameter_node }}"
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Check if feature_flag module was completed successfully (check_mode)
+    assert:
+      that:
+        - result_check_mode is success
+
   - name: Enable feature flag
     rabbitmq_feature_flag:
       name: "{{ parameter_name }}"
@@ -14,6 +26,36 @@
       that:
         - result is success
 
+  - name: Ensure that module reported the same 'changed' value with or without check mode
+    assert:
+      that:
+        - result.changed == result_check_mode.changed
+
   - name: Check if specified feature flag is enabled
     shell: "rabbitmqctl -q list_feature_flags | grep {{ parameter_name }}"
     register: ctl_result
+
+  - name: Idempotent - Enable feature flag (check_mode)
+    rabbitmq_feature_flag:
+      name: "{{ parameter_name }}"
+      node: "{{ parameter_node }}"
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Idempotent - Check if feature_flag module was completed successfully (check_mode)
+    assert:
+      that:
+        - result_check_mode is success
+        - result_check_mode is not changed
+
+  - name: Idempotent - Enable feature flag
+    rabbitmq_feature_flag:
+      name: "{{ parameter_name }}"
+      node: "{{ parameter_node }}"
+    register: result
+
+  - name: Idempotent - Check if feature_flag module was completed successfully
+    assert:
+      that:
+        - result is success
+        - result is not changed

--- a/tests/unit/modules/test_rabbitmq_feature_flag.py
+++ b/tests/unit/modules/test_rabbitmq_feature_flag.py
@@ -60,4 +60,3 @@ class TestRabbitMQFeatureFlagModule(ModuleTestCase):
                 self.module.main()
             except AnsibleExitJson as e:
                 self._assert(e, 'changed', False)
-

--- a/tests/unit/modules/test_rabbitmq_feature_flag.py
+++ b/tests/unit/modules/test_rabbitmq_feature_flag.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.community.rabbitmq.plugins.modules import rabbitmq_feature_flag
+
+from ansible_collections.community.rabbitmq.tests.unit.compat.mock import patch
+from ansible_collections.community.rabbitmq.tests.unit.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class TestRabbitMQFeatureFlagModule(ModuleTestCase):
+    def setUp(self):
+        super(TestRabbitMQFeatureFlagModule, self).setUp()
+        self.module = rabbitmq_feature_flag
+
+    def tearDown(self):
+        super(TestRabbitMQFeatureFlagModule, self).tearDown()
+
+    def _assert(self, exc, attribute, expected_value, msg=''):
+        value = exc.message[attribute] if hasattr(exc, attribute) else exc.args[0][attribute]
+        assert value == expected_value, msg
+
+    def test_without_required_parameters(self):
+        """Failure must occur when all parameters are missing."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_feature_flag.RabbitMqFeatureFlag._exec')
+    def test_enable_feature_flag(self, _exec, get_bin_path):
+        """Test enabling feature flag."""
+        set_module_args({
+            'name': 'maintenance_mode_status',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        for out in 'name\tstate\nmaintenance_mode_status\tdisabled', 'name\tstate\nmaintenance_mode_status\tdisabled\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', True)
+
+    @patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    @patch('ansible_collections.community.rabbitmq.plugins.modules.rabbitmq_feature_flag.RabbitMqFeatureFlag._exec')
+    def test_enable_no_change_feature_flag(self, _exec, get_bin_path):
+        """Test that there is no change when enabling feature flag which is already enabled"""
+        set_module_args({
+            'name': 'maintenance_mode_status',
+            'node': 'rabbit@node-1',
+        })
+        get_bin_path.return_value = '/rabbitmqctl'
+
+        for out in 'name\tstate\nmaintenance_mode_status\tenabled', 'name\tstate\nmaintenance_mode_status\tenabled\n':
+            _exec.return_value = out.splitlines()
+            try:
+                self.module.main()
+            except AnsibleExitJson as e:
+                self._assert(e, 'changed', False)
+


### PR DESCRIPTION
##### SUMMARY
module: rabbitmq_feature_flag
short_description: Enables feature flag
description: Allows to enable specified feature flag
options:
- name:
    description: Feature flag name
    type: str
    required: true
- node:
    description: erlang node name of the target rabbit node
    type: str
    required: false
    default: rabbit

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
rabbitmq_feature_flag