### PR TITLE
Refactor `_exec` parameter `run_in_check_mode` for a name that improves readability

### DIFF
--- a/plugins/modules/rabbitmq_feature_flag.py
+++ b/plugins/modules/rabbitmq_feature_flag.py
@@ -47,8 +47,8 @@ class RabbitMqFeatureFlag(object):
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
         self.state = self.get_flag_state()
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()

--- a/plugins/modules/rabbitmq_global_parameter.py
+++ b/plugins/modules/rabbitmq_global_parameter.py
@@ -80,8 +80,8 @@ class RabbitMqGlobalParameter(object):
 
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()

--- a/plugins/modules/rabbitmq_parameter.py
+++ b/plugins/modules/rabbitmq_parameter.py
@@ -73,8 +73,8 @@ class RabbitMqParameter(object):
 
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.strip().splitlines()

--- a/plugins/modules/rabbitmq_plugin.py
+++ b/plugins/modules/rabbitmq_plugin.py
@@ -111,8 +111,8 @@ class RabbitMqPlugins(object):
         else:
             self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmq_plugins]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()

--- a/plugins/modules/rabbitmq_policy.py
+++ b/plugins/modules/rabbitmq_policy.py
@@ -105,11 +105,11 @@ class RabbitMqPolicy(object):
 
     def _exec(self,
               args,
-              run_in_check_mode=False,
+              force_exec_in_check_mode=False,
               split_lines=True,
               add_vhost=True):
         if (not self._module.check_mode
-                or (self._module.check_mode and run_in_check_mode)):
+                or (self._module.check_mode and force_exec_in_check_mode)):
             cmd = [self._rabbitmqctl, '-q', '-n', self._node]
 
             if add_vhost:

--- a/plugins/modules/rabbitmq_upgrade.py
+++ b/plugins/modules/rabbitmq_upgrade.py
@@ -49,8 +49,8 @@ class RabbitMqUpgrade(object):
         self.node = node
         self.result = result
 
-    def _exec(self, binary, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, binary, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self.module.get_bin_path(binary, True)]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()

--- a/plugins/modules/rabbitmq_user_limits.py
+++ b/plugins/modules/rabbitmq_user_limits.py
@@ -95,9 +95,9 @@ class RabbitMqUserLimits(object):
 
     def _exec(self,
               args,
-              run_in_check_mode=False):
+              force_exec_in_check_mode=False):
 
-        if not self._module.check_mode or (self._module.check_mode and run_in_check_mode):
+        if not self._module.check_mode or (self._module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmqctl, '-q']
             if self._node is not None:
                 cmd.extend(['-n', self._node])

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -61,8 +61,8 @@ class RabbitMqVhost(object):
         self._tracing = False
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
+    def _exec(self, args, force_exec_in_check_mode=False):
+        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
             cmd = [self._rabbitmqctl, '-q', '-n', self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()


### PR DESCRIPTION
This PR has been triggered by [this comment](https://github.com/ansible-collections/community.rabbitmq/pull/65#discussion_r672111654) in PR #65 (thanks to @Andersson007).

Hopefully it improves the code readability by renaming `run_in_check_mode` parameter to `force_exec_in_check_mode` in the `_exec` function used in multiple modules.
