### PR TITLE
Remove centos8 from CI matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,8 +120,6 @@ stages:
             #  test: centos6
             #- name: CentOS 7
             #  test: centos7
-            #- name: CentOS 8
-            #  test: centos8
             #- name: Fedora 33
             #  test: fedora33
             #- name: Fedora 34
@@ -161,8 +159,6 @@ stages:
             #  test: centos6
             #- name: CentOS 7
             #  test: centos7
-            #- name: CentOS 8
-            #  test: centos8
             #- name: Fedora 32
             #  test: fedora32
             #- name: Fedora 33
@@ -189,8 +185,6 @@ stages:
             #  test: centos6
             #- name: CentOS 7
             #  test: centos7
-            #- name: CentOS 8
-            #  test: centos8
             #- name: Fedora 31
             #  test: fedora31
             #- name: Fedora 32


### PR DESCRIPTION
##### SUMMARY
Remove centos8 from CI matrix

Relates to https://github.com/ansible-collections/news-for-maintainers/issues/3