### PR TITLE
Add sanity test ignore entries for 2.14

### DIFF
--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
The ansible-core devel branch has been updated to version 2.14.0. This
patch copies the 2.13 test ignore entries so that they will be ignored
for 2.14.

Relates to https://github.com/ansible-collections/news-for-maintainers/issues/13