### PR TITLE
Update doc elements to pass validate-modules test

### DIFF
--- a/plugins/lookup/rabbitmq.py
+++ b/plugins/lookup/rabbitmq.py
@@ -5,8 +5,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    lookup: rabbitmq
-    author: John Imison <@Im0>
+    name: rabbitmq
+    author: John Imison (@Im0)
     short_description: Retrieve messages from an AMQP/AMQPS RabbitMQ queue.
     description:
         - This lookup uses a basic get to retrieve all, or a limited number C(count), messages from a RabbitMQ queue.


### PR DESCRIPTION
ansible-test's validate-modules sanity test was extended to also
validate the documentation (and thus configuration) for (documentable)
plugins. This introduced a schema which required updating of
documentation in order for the test to pass.

See https://github.com/ansible/ansible/pull/71734
