### PR TITLE
CI: add testing against ansible-core 2.13

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_13
+    displayName: Sanity & Units 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.13/sanity/1'
+            - name: Units
+              test: '2.13/units/1'
+
   - stage: Ansible_2_12
     displayName: Sanity & Units 2.12
     dependsOn: []
@@ -128,6 +140,19 @@ stages:
             #  test: opensuse15py2
             #- name: openSUSE 15 py3
             #  test: opensuse15
+            #- name: Ubuntu 18.04
+            #  test: ubuntu1804
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+
+  - stage: Docker_2_13
+    displayName: Docker 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/linux/{0}/1
+          targets:
             #- name: Ubuntu 18.04
             #  test: ubuntu1804
             - name: Ubuntu 20.04
@@ -280,11 +305,13 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_13
       - Ansible_2_12
       - Ansible_2_11
       - Ansible_2_10
       - Ansible_2_9
       - Docker_devel
+      - Docker_2_13
       - Docker_2_12
       - Docker_2_11
       - Docker_2_10


### PR DESCRIPTION
This patch adds stable-2.13 to the testing matrix as it is now available
for testing.

See https://github.com/ansible-collections/news-for-maintainers/issues/14

Closes #117 