### PR TITLE
Add an option to allow rabbitmq_user to use API for managing users

### DIFF
--- a/changelogs/fragments/120-api-managed-users.yaml
+++ b/changelogs/fragments/120-api-managed-users.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_user - add support to user manipulation through RabbitMQ API (https://github.com/ansible-collections/community.rabbitmq/issues/76)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: rabbitmq
-version: 1.2.3
+version: 1.3.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/tests/integration/targets/rabbitmq_user/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/main.yml
@@ -5,6 +5,8 @@
 
   - import_tasks: tests.yml
 
+  - import_tasks: tests_api.yml
+
   - import_tasks: tests.yml
     environment:
       RABBITMQ_NODENAME: test

--- a/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
@@ -1,0 +1,131 @@
+---
+
+- name: Test add user
+  block:
+    - name: Add user
+      rabbitmq_user: user=joe password=changeme login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that user adding succeeds with a change
+      assert:
+        that:
+          - add_user.changed == true
+
+- name: Test add user idempotence
+  block:
+    - name: Add user
+      rabbitmq_user: user=joe password=changeme login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that user adding succeeds without a change
+      assert:
+        that:
+          - add_user.changed == false
+
+- name: Test change user permissions
+  block:
+    - name: Add user with permissions
+      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.* login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that changing permissions succeeds with a change
+      assert:
+        that:
+          - add_user.changed == true
+
+- name: Test change user permissions idempotence
+  block:
+    - name: Add user with permissions
+      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.* login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that changing permissions succeeds without a change
+      assert:
+        that:
+          - add_user.changed == false
+
+- name: Test change user topic permissions
+  block:
+    - name: Add user with topic permissions
+      rabbitmq_user:
+        user: joe
+        password: changeme
+        topic_permissions:
+          - vhost: /
+            exchange: amq.topic
+            read_priv: .*
+            write_priv: .*
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1
+      register: add_user
+
+    - name: Check that changing topic permissions succeeds with a change
+      assert:
+        that:
+          - add_user.changed == true
+
+- name: Test change user topic permissions idempotence
+  block:
+    - name: Add user with topic permissions
+      rabbitmq_user:
+        user: joe
+        password: changeme
+        topic_permissions:
+          - vhost: /
+            exchange: amq.topic
+            read_priv: .*
+            write_priv: .*
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1
+      register: add_user
+
+    - name: Check that changing topic permissions succeeds without a change
+      assert:
+        that:
+          - add_user.changed == false
+
+- name: Test add user tags
+  block:
+    - name: Add user with tags
+      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.* tags=management,administrator login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that adding tags succeeds with a change
+      assert:
+        that:
+          - add_user.changed == true
+
+- name: Test add user tags idempotence
+  block:
+    - name: Add user with tags
+      rabbitmq_user: user=joe password=changeme vhost=/ configure_priv=.* read_priv=.* write_priv=.* tags=administrator,management login_user=guest login_password=guest login_host=127.0.0.1
+      register: add_user
+
+    - name: Check that adding tags succeeds without a change
+      assert:
+        that:
+          - add_user.changed == false
+
+- name: Test remove user
+  block:
+    - name: Remove user
+      rabbitmq_user: user=joe state=absent login_user=guest login_password=guest login_host=127.0.0.1
+      register: remove_user
+
+    - name: Check that user removing succeeds with a change
+      assert:
+        that:
+          - remove_user.changed == true
+
+- name: Test remove user idempotence
+  block:
+    - name: Remove user
+      rabbitmq_user: user=joe state=absent login_user=guest login_password=guest login_host=127.0.0.1
+      register: remove_user
+
+    - name: Check that user removing succeeds without a change
+      assert:
+        that:
+          - remove_user.changed == false


### PR DESCRIPTION
##### SUMMARY

As discussed in #76, this contains the solution we used in our company to manage rabbitmq users using the API.

Fixes #76

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ADDITIONAL INFORMATION 
With this feature is possible to create, delete and also manage your users. 
Unfortunately we won't be able to help with much more with the PR in the coming weeks so any help would be appreciated.