### PR TITLE
doc: set booleans to true/false for consistency

### DIFF
--- a/plugins/modules/rabbitmq_exchange.py
+++ b/plugins/modules/rabbitmq_exchange.py
@@ -35,7 +35,7 @@ options:
             - whether exchange is durable or not
         type: bool
         required: false
-        default: yes
+        default: true
     exchange_type:
         description:
             - type for the exchange
@@ -49,13 +49,13 @@ options:
             - if the exchange should delete itself after all queues/exchanges unbound from it
         type: bool
         required: false
-        default: no
+        default: false
     internal:
         description:
             - exchange is available only for other exchanges
         type: bool
         required: false
-        default: no
+        default: false
     arguments:
         description:
             - extra arguments for exchange. If defined this argument is a key/value dictionary

--- a/plugins/modules/rabbitmq_plugin.py
+++ b/plugins/modules/rabbitmq_plugin.py
@@ -28,7 +28,7 @@ options:
       - Only enable missing plugins.
       - Does not disable plugins that are not in the names list.
     type: bool
-    default: "no"
+    default: false
   state:
     description:
       - Specify if plugins are to be enabled or disabled.
@@ -67,7 +67,7 @@ EXAMPLES = r'''
   community.rabbitmq.rabbitmq_plugin:
     names: rabbitmq_management,rabbitmq_management_visualiser,rabbitmq_shovel,rabbitmq_shovel_management
     state: enabled
-    new_only: 'yes'
+    new_only: true
 
 - name: Enables the rabbitmq_peer_discovery_aws plugin without requiring a broker connection.
   community.rabbitmq.rabbitmq_plugin:

--- a/plugins/modules/rabbitmq_queue.py
+++ b/plugins/modules/rabbitmq_queue.py
@@ -34,12 +34,12 @@ options:
         description:
             - whether queue is durable or not
         type: bool
-        default: 'yes'
+        default: true
     auto_delete:
         description:
             - if the queue should delete itself after all queues/queues unbound from it
         type: bool
-        default: 'no'
+        default: false
     message_ttl:
         description:
             - How long a message can live in queue before it is discarded (milliseconds)

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -92,7 +92,7 @@ options:
     description:
       - Deletes and recreates the user.
     type: bool
-    default: 'no'
+    default: false
   state:
     description:
       - Specify if user is to be added or removed

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -31,7 +31,7 @@ options:
     description:
       - Enable/disable tracing for a vhost
     type: bool
-    default: 'no'
+    default: false
     aliases: [trace]
   state:
     description:


### PR DESCRIPTION
The Ansible Steering Committee voted to make all docs refer to booleans as true/false, as there is generally a mix of
yes/no/True/False/true/false.

Fixes #134