### PR TITLE
Fixing publishing to exchanges

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -142,8 +142,10 @@ stages:
             #  test: opensuse15
             #- name: Ubuntu 18.04
             #  test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
+            #- name: Ubuntu 20.04
+            #  test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
 
   - stage: Docker_2_13
     displayName: Docker 2.13

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -142,8 +142,8 @@ stages:
             #  test: opensuse15
             #- name: Ubuntu 18.04
             #  test: ubuntu1804
-            #- name: Ubuntu 20.04
-            #  test: ubuntu2004
+            - name: Ubuntu 20.04
+              test: ubuntu2004
             - name: Ubuntu 22.04
               test: ubuntu2204
 

--- a/changelogs/fragments/140-fixing-publishing-to-exchanges.yaml
+++ b/changelogs/fragments/140-fixing-publishing-to-exchanges.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rabbitmq_plugin - fixing issue with publishing to exchanges and adding exchange documentation examples
+  - rabbitmq_plugin - fixing issue with publishing to exchanges and adding exchange documentation examples. Publishing to an exchange or queue is now mutually exclusive.

--- a/changelogs/fragments/140-fixing-publishing-to-exchanges.yaml
+++ b/changelogs/fragments/140-fixing-publishing-to-exchanges.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_plugin - fixing issue with publishing to exchanges and adding exchange documentation examples

--- a/plugins/module_utils/rabbitmq.py
+++ b/plugins/module_utils/rabbitmq.py
@@ -222,7 +222,7 @@ class RabbitClient():
             if self.routing_key is None:
                 args['routing_key'] = self.exchange
 
-        #self.module.fail_json(msg="%s %s %s" % (to_native(self.queue), to_native(self.exchange), to_native(self.routing_key)))
+        # self.module.fail_json(msg="%s %s %s" % (to_native(self.queue), to_native(self.exchange), to_native(self.routing_key)))
         try:
             self.conn_channel.basic_publish(**args)
             return True

--- a/plugins/module_utils/rabbitmq.py
+++ b/plugins/module_utils/rabbitmq.py
@@ -57,6 +57,8 @@ class RabbitClient():
         self.port = self.params['port']
         self.vhost = self.params['vhost']
         self.queue = self.params['queue']
+        self.exchange = self.params['exchange']
+        self.routing_key = self.params['routing_key']
         self.headers = self.params['headers']
         self.cafile = self.params['cafile']
         self.certfile = self.params['certfile']
@@ -160,8 +162,6 @@ class RabbitClient():
         if self.params.get("body") is not None:
             args = dict(
                 body=self.params.get("body"),
-                exchange=self.params.get("exchange"),
-                routing_key=self.params.get("routing_key"),
                 properties=pika.BasicProperties(content_type=self.content_type, delivery_mode=1, headers=self.headers))
 
         # If src (file) is defined and content_type is left as default, do a mime lookup on the file
@@ -173,8 +173,6 @@ class RabbitClient():
 
             args = dict(
                 body=self._read_file(self.params.get("src")),
-                exchange=self.params.get("exchange"),
-                routing_key=self.params.get("routing_key"),
                 properties=pika.BasicProperties(content_type=self.content_type,
                                                 delivery_mode=1,
                                                 headers=self.headers
@@ -182,22 +180,21 @@ class RabbitClient():
         elif self.params.get("src") is not None:
             args = dict(
                 body=self._read_file(self.params.get("src")),
-                exchange=self.params.get("exchange"),
-                routing_key=self.params.get("routing_key"),
                 properties=pika.BasicProperties(content_type=self.content_type,
                                                 delivery_mode=1,
                                                 headers=self.headers
                                                 ))
 
         try:
-            # If queue is not defined, RabbitMQ will return the queue name of the automatically generated queue.
-            if self.queue is None:
-                result = self.conn_channel.queue_declare(durable=self.params.get("durable"),
+            # If queue and exchange is not defined post to random queue, RabbitMQ will return the queue name of the automatically generated queue.
+            if self.queue is None and self.exchange is None:
+                result = self.conn_channel.queue_declare(queue='',
+                                                         durable=self.params.get("durable"),
                                                          exclusive=self.params.get("exclusive"),
                                                          auto_delete=self.params.get("auto_delete"))
                 self.conn_channel.confirm_delivery()
                 self.queue = result.method.queue
-            else:
+            elif self.queue is not None and self.exchange is None:
                 self.conn_channel.queue_declare(queue=self.queue,
                                                 durable=self.params.get("durable"),
                                                 exclusive=self.params.get("exclusive"),
@@ -207,12 +204,25 @@ class RabbitClient():
             self.module.fail_json(msg="Queue declare issue: %s" % to_native(e))
 
         # https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/cloudstack.py#L150
-        if args['routing_key'] is None:
+        # If routing key is not defined, but, the queue is... we will use the queue name as routing_key.
+        if self.routing_key is not None:
+            args['routing_key'] = self.routing_key
+        elif self.routing_key is None and self.queue is not None:
             args['routing_key'] = self.queue
+        elif self.routing_key is None and self.exchange is not None:
+            args['routing_key'] = self.exchange
+        else:
+            args['routing_key'] = ''
 
-        if args['exchange'] is None:
+        # If exchange is not specified use the default/nameless exchange
+        if self.exchange is None:
             args['exchange'] = ''
+        else:
+            args['exchange'] = self.exchange
+            if self.routing_key is None:
+                args['routing_key'] = self.exchange
 
+        #self.module.fail_json(msg="%s %s %s" % (to_native(self.queue), to_native(self.exchange), to_native(self.routing_key)))
         try:
             self.conn_channel.basic_publish(**args)
             return True

--- a/plugins/modules/rabbitmq_publish.py
+++ b/plugins/modules/rabbitmq_publish.py
@@ -228,13 +228,12 @@ def main():
         rabbitmq.close_connection()
         if (rabbitmq.queue is not None):
             module.exit_json(changed=True, result={"msg": "Successfully published to queue %s" % rabbitmq.queue,
-                                               "queue": rabbitmq.queue,
-                                               "content_type": rabbitmq.content_type})
+                             "queue": rabbitmq.queue, "content_type": rabbitmq.content_type}
+                             )
         elif (rabbitmq.exchange is not None):
             module.exit_json(changed=True, result={"msg": "Successfully published to exchange %s" % rabbitmq.exchange,
-                                               "routing_key": rabbitmq.routing_key,
-                                               "exchange": rabbitmq.exchange,
-                                               "content_type": rabbitmq.content_type})
+                             "routing_key": rabbitmq.routing_key, "exchange": rabbitmq.exchange, "content_type": rabbitmq.content_type}
+                             )
 
     else:
         rabbitmq.close_connection()

--- a/plugins/modules/rabbitmq_publish.py
+++ b/plugins/modules/rabbitmq_publish.py
@@ -178,7 +178,9 @@ EXAMPLES = r'''
 RETURN = r'''
 result:
   description:
-    - Contains the status I(msg), content type I(content_type) and the queue name I(queue).
+    - If posted to an exchange, the result contains the status I(msg), content type I(content_type) the exchange name I(exchange)
+    - and the routing key I(routing_key).
+    - If posted to a queue, the result contains the status I(msg), content type I(content_type) and the queue name I(queue).
   returned: success
   type: dict
   sample: |
@@ -224,12 +226,22 @@ def main():
 
     if rabbitmq.basic_publish():
         rabbitmq.close_connection()
-        module.exit_json(changed=True, result={"msg": "Successfully published to queue %s" % rabbitmq.queue,
+        if (rabbitmq.queue is not None):
+            module.exit_json(changed=True, result={"msg": "Successfully published to queue %s" % rabbitmq.queue,
                                                "queue": rabbitmq.queue,
                                                "content_type": rabbitmq.content_type})
+        elif (rabbitmq.exchange is not None):
+            module.exit_json(changed=True, result={"msg": "Successfully published to exchange %s" % rabbitmq.exchange,
+                                               "routing_key": rabbitmq.routing_key,
+                                               "exchange": rabbitmq.exchange,
+                                               "content_type": rabbitmq.content_type})
+
     else:
         rabbitmq.close_connection()
-        module.fail_json(changed=False, msg="Unsuccessful publishing to queue %s" % rabbitmq.queue)
+        if (rabbitmq.queue is not None):
+            module.fail_json(changed=False, msg="Unsuccessful publishing to queue %s" % rabbitmq.queue)
+        elif (rabbitmq.exchange is not None):
+            module.fail_json(changed=False, msg="Unsuccessful publishing to exchange %s" % rabbitmq.exchange)
 
 
 if __name__ == '__main__':

--- a/plugins/modules/rabbitmq_publish.py
+++ b/plugins/modules/rabbitmq_publish.py
@@ -49,10 +49,12 @@ options:
   queue:
     description:
       - The queue to publish a message to.  If no queue is specified, RabbitMQ will return a random queue name.
+      - A C(queue) cannot be provided if an C(exchange) is specified.
     type: str
   exchange:
     description:
       - The exchange to publish a message to.
+      - An C(exchange) cannot be provided if a C(queue) is specified.
     type: str
   routing_key:
     description:
@@ -125,6 +127,21 @@ author: "John Imison (@Im0)"
 '''
 
 EXAMPLES = r'''
+- name: Publish to an exchange
+  community.rabbitmq.rabbitmq_publish:
+    exchange: exchange1
+    url: "amqp://guest:guest@192.168.0.32:5672/%2F"
+    body: "Hello exchange from ansible module rabbitmq_publish"
+    content_type: "text/plain"
+
+- name: Publish to an exchange with routing_key
+  community.rabbitmq.rabbitmq_publish:
+    exchange: exchange1
+    routing_key: queue1
+    url: "amqp://guest:guest@192.168.0.32:5672/%2F"
+    body: "Hello queue via exchange routing_key from ansible module rabbitmq_publish"
+    content_type: "text/plain"
+
 - name: Publish a message to a queue with headers
   community.rabbitmq.rabbitmq_publish:
     url: "amqp://guest:guest@192.168.0.32:5672/%2F"
@@ -133,7 +150,6 @@ EXAMPLES = r'''
     content_type: "text/plain"
     headers:
       myHeader: myHeaderValue
-
 
 - name: Publish a file to a queue
   community.rabbitmq.rabbitmq_publish:
@@ -184,7 +200,7 @@ from ansible_collections.community.rabbitmq.plugins.module_utils.rabbitmq import
 def main():
     argument_spec = RabbitClient.rabbitmq_argument_spec()
     argument_spec.update(
-        exchange=dict(type='str', default=''),
+        exchange=dict(type='str'),
         routing_key=dict(type='str', required=False, no_log=False),
         body=dict(type='str', required=False),
         src=dict(aliases=['file'], type='path', required=False),
@@ -199,7 +215,7 @@ def main():
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[['body', 'src']],
+        mutually_exclusive=[['body', 'src'], ['queue', 'exchange']],
         required_together=[['cafile', 'certfile', 'keyfile']],
         supports_check_mode=False
     )

--- a/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
@@ -11,7 +11,7 @@
 
 - name: Install pika and requests
   pip:
-    name: pika<1.3.0,requests
+    name: pika==1.3.0,requests
     state: latest
   delegate_to: localhost
 

--- a/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
@@ -136,7 +136,7 @@
 - assert:
     that:
       - "rabbitmq_vhost_error is failed"
-      - "'NOT_ALLOWED' in rabbitmq_vhost_error.msg"
+      - ("'NOT_ALLOWED' in rabbitmq_vhost_error.msg") or ("'Connection issue' in rabbitmq_vhost_error.msg")
 
 # Tidy up
 - name: Uninstall pika and requests

--- a/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/lookup_rabbitmq/tasks/ubuntu.yml
@@ -11,7 +11,7 @@
 
 - name: Install pika and requests
   pip:
-    name: pika<1.0.0,requests
+    name: pika<1.3.0,requests
     state: latest
   delegate_to: localhost
 

--- a/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -1,6 +1,6 @@
 - name: Install requests and pika
   pip:
-    name: requests,pika<1.3.0
+    name: requests,pika==1.3.0
     state: present
   delegate_to: localhost
 

--- a/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -6,7 +6,7 @@
 
 - name: RabbitMQ basic publish test
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'publish_test'
     body: "Hello world from ansible module rabbitmq_publish"
     content_type: "text/plain"
@@ -24,7 +24,7 @@
 # Testing random queue
 - name: Publish to random queue
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     body: "RANDOM QUEUE POST"
     content_type: "text/plain"
   register: rabbit_random_queue_output
@@ -45,7 +45,7 @@
 
 - name: Publish binary to a queue
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: publish_test
     src: "{{ remote_tmp_dir }}/image.gif"
   register: rabbitmq_publish_file
@@ -59,7 +59,7 @@
 
 - name: Raise error for src and body defined
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'publish_test'
     src: "{{ remote_tmp_dir }}/image.gif"
     body: blah
@@ -74,7 +74,7 @@
 
 - name: Publish a file that does not exist
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'publish_test'
     src: 'aaaaaaajax-loader.gif'
   register: file_missing_fail
@@ -123,7 +123,7 @@
 
 - name: Publish with proto/host/port/user and url
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     proto: amqp
     host: localhost
     port: 5672
@@ -143,7 +143,7 @@
 
 - name: Publish headers to queue
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'publish_test'
     body: blah
     headers:
@@ -155,7 +155,7 @@
 
 - name: Publish headers with file
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'publish_test'
     src: "{{ remote_tmp_dir }}/image.gif"
     headers:
@@ -167,7 +167,7 @@
 
 - name: Collect all messages off the publish queue
   set_fact:
-    messages: "{{ lookup('community.rabbitmq.rabbitmq', url='amqp://guest:guest@localhost:5672/%2F', queue='publish_test') }}"
+    messages: "{{ lookup('community.rabbitmq.rabbitmq', url='amqp://guest:guest@127.0.0.1:5672/%2F', queue='publish_test') }}"
   delegate_to: localhost
 
 - name: Check contents of published messages
@@ -186,7 +186,7 @@
 
 - name: Check that queue and exchange are mutually exclusive
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     queue: 'fail_queue'
     exchange: 'fail_exchange'
     body: "Queue and exchange mutually exclusive should fail"
@@ -231,7 +231,7 @@
 
 - name: RabbitMQ basic exchange publish test
   rabbitmq_publish:
-    url: "amqp://guest:guest@localhost:5672/%2F"
+    url: "amqp://guest:guest@127.0.0.1:5672/%2F"
     exchange: 'pub_test_exchange'
     body: "Hello world pub_test_exchange exchange from ansible module rabbitmq_publish"
     content_type: "text/plain"
@@ -249,7 +249,7 @@
 
 - name: Retrieve messages from pub_test_exchange_queue
   set_fact:
-    rabbitmq_exchange_msg: "{{ lookup('community.rabbitmq.rabbitmq', url='amqp://guest:guest@localhost:5672/%2f/pub_test_exchange_queue', queue='pub_test_exchange_queue') }}"
+    rabbitmq_exchange_msg: "{{ lookup('community.rabbitmq.rabbitmq', url='amqp://guest:guest@127.0.0.1:5672/%2f/pub_test_exchange_queue', queue='pub_test_exchange_queue') }}"
   ignore_errors: yes
   register: rabbitmq_pub_test_exchange_queue
   delegate_to: localhost

--- a/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -1,6 +1,6 @@
 - name: Install requests and pika
   pip:
-    name: requests,pika<1.0.0
+    name: requests,pika<1.3.0
     state: present
   delegate_to: localhost
 

--- a/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -182,3 +182,93 @@
 #      - messages[3]['headers']['myHeader'] is defined
 #      - messages[4]['headers']['filename'] is defined
 #      - messages[4]['headers']['secondHeader'] is defined
+#
+
+- name: Check that queue and exchange are mutually exclusive
+  rabbitmq_publish:
+    url: "amqp://guest:guest@localhost:5672/%2F"
+    queue: 'fail_queue'
+    exchange: 'fail_exchange'
+    body: "Queue and exchange mutually exclusive should fail"
+    content_type: "text/plain"
+  register: rabbit_mutually_exclusive
+  delegate_to: localhost
+  ignore_errors: true
+
+- assert:
+    that:
+      - "rabbit_basic_fail_output1 is failed"
+      - "'parameters are mutually exclusive' in rabbit_mutually_exclusive.msg"
+
+# Publish to exchange testing
+# - Create an exchange (pub_test_exchange) and a queue (pub_test_exchange_queue)
+# - Bind exchange and queue
+# - Send message to exchange
+# - Check message arrived in queue
+
+- name: Add test requisites
+  block:
+    - name: Add exchange
+      rabbitmq_exchange:
+        name: "pub_test_exchange"
+        type: fanout
+
+    - name: Add queue
+      rabbitmq_queue:
+        name: pub_test_exchange_queue
+
+    - name: Add binding
+      rabbitmq_binding:
+        source: pub_test_exchange
+        destination: pub_test_exchange_queue
+        type: queue
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: RabbitMQ basic exchange publish test
+  rabbitmq_publish:
+    url: "amqp://guest:guest@localhost:5672/%2F"
+    exchange: 'pub_test_exchange'
+    body: "Hello world pub_test_exchange exchange from ansible module rabbitmq_publish"
+    content_type: "text/plain"
+  register: rabbit_exchange_output1
+  delegate_to: localhost
+
+- assert:
+    that:
+      - "rabbit_exchange_output1 is not failed"
+      - "'pub_test_exchange' in rabbit_exchange_output1.result.msg"
+
+- name: Wait 2 seconds to make sure message has been delivered
+  pause:
+    seconds: 2
+
+- name: Retrieve messages from pub_test_exchange_queue
+  set_fact:
+    rabbitmq_exchange_msg: "{{ lookup('community.rabbitmq.rabbitmq', url='amqp://guest:guest@localhost:5672/%2f/pub_test_exchange_queue', queue='pub_test_exchange_queue') }}"
+  ignore_errors: yes
+  register: rabbitmq_pub_test_exchange_queue
+  delegate_to: localhost
+
+- name: Debug out rabbitmq_pub_test_exchange_queue task result
+  debug:
+    var: rabbitmq_pub_test_exchange_queue
+
+- name: Debug out the set_fact rabbitmq_exchange_msg
+  debug:
+    var: rabbitmq_exchange_msg
+
+- name: Ensure one message was received
+  assert:
+    that:
+      - "rabbitmq_pub_test_exchange_queue is not failed"
+      - rabbitmq_exchange_msg | length == 1
+
+- name: Ensure first message contains a string
+  assert:
+    that:
+      - "'pub_test_exchange exchange' in rabbitmq_exchange_msg[0].msg"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #138 

Updating to fix publishing to exchanges.
Updating documentation examples.
Queue and exchange options are now mutually exclusive.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/rabbitmq.py 
modules/rabbitmq_publish.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Notes are in #138 - This PR fixes up some of the logic when posting to an exchange.  Previously if an exchange was specified but no queue, the module would also post the message to a random queue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
