### PR TITLE
CI: add 2.15 tests, create ignore-2.16 to prevent CI failure

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_15
+    displayName: Sanity & Units 2.15
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.15/sanity/1'
+            - name: Units
+              test: '2.15/units/1'
+
   - stage: Ansible_2_14
     displayName: Sanity & Units 2.14
     dependsOn: []
@@ -118,6 +130,23 @@ stages:
             #  test: opensuse15
             #- name: Ubuntu 18.04
             #  test: ubuntu1804
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+            # Currently 20.04 is causing devel to fail.  This maybe due to Ubuntu 20.04 running python
+            # 3.8, however, ansible-test requires 3.9+.  This means ansible test spins up a controller
+            # and target container which is probably why rabbitmq_publish is not able to connect to
+            # rabbitmq on localhost.
+            #- name: Ubuntu 20.04
+            #  test: ubuntu2004
+
+  - stage: Docker_2_15
+    displayName: Docker 2.15
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.15/linux/{0}/1
+          targets:
             - name: Ubuntu 22.04
               test: ubuntu2204
             # Currently 20.04 is causing devel to fail.  This maybe due to Ubuntu 20.04 running python
@@ -192,10 +221,12 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
       - Docker_devel
+      - Docker_2_15
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,4 @@
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang
+plugins/module_utils/version.py pylint:unused-import
+tests/unit/compat/builtins.py pylint:unused-import


### PR DESCRIPTION
Add tests against upstream stable 2.15
https://github.com/ansible-collections/news-for-maintainers/issues/41
