### PR TITLE
Define Default Action Group

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,18 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  rabbitmq:
+    - community.rabbitmq.rabbitmq_binding
+    - community.rabbitmq.rabbitmq_exchange
+    - community.rabbitmq.rabbitmq_feature_flag
+    - community.rabbitmq.rabbitmq_global_parameter
+    - community.rabbitmq.rabbitmq_parameter
+    - community.rabbitmq.rabbitmq_plugin
+    - community.rabbitmq.rabbitmq_policy
+    - community.rabbitmq.rabbitmq_publish
+    - community.rabbitmq.rabbitmq_queue
+    - community.rabbitmq.rabbitmq_upgrade
+    - community.rabbitmq.rabbitmq_user
+    - community.rabbitmq.rabbitmq_user_limits
+    - community.rabbitmq.rabbitmq_vhost
+    - community.rabbitmq.rabbitmq_vhost_limits


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR defines an action group for all collection modules.

When same module is frequently called with same arguments, we can use `module_defaults` to avoid duplications. Since Ansible 2.7, we can group modules that share common sets of parameters. And since ansible-core 2.12, collections can define its own groups via `action_groups` on `runtime.yml`.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_module_defaults.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `rabbitmq` action group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:

```yaml
# playbook.yaml
- name: rabbitmq
  hosts: all
  module_defaults:
    community.rabbitmq.rabbitmq_exchanges:
      login_user: "admin"
      login_password: "admin"
    community.rabbitmq.rabbitmq_queues:
      login_user: "admin"
      login_password: "admin"
    # ...
  roles:
    - "exchanges"
    - "queues"
```

After:

```yaml
# playbook.yaml
- name: rabbitmq
  hosts: all
  module_defaults:
    group/rabbitmq:
      login_user: "admin"
      login_password: "admin"
  roles:
    - "exchanges"
    - "queues"
```