### PR TITLE
CI: update container, fix include tasks and linting

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
+      image: quay.io/ansible/azure-pipelines-test-container:4.0.1
 
 pool: Standard
 

--- a/tests/integration/targets/lookup_rabbitmq/tasks/main.yml
+++ b/tests/integration/targets/lookup_rabbitmq/tasks/main.yml
@@ -1,5 +1,5 @@
 # Rabbitmq lookup
-- include: ubuntu.yml
-  when: 
+- include_tasks: ubuntu.yml
+  when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'trusty'

--- a/tests/integration/targets/rabbitmq_publish/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/main.yml
@@ -1,5 +1,5 @@
 # Rabbitmq lookup
-- include: ubuntu.yml
-  when: 
+- include_tasks: ubuntu.yml
+  when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'trusty'

--- a/tests/integration/targets/rabbitmq_queue/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_queue/tasks/main.yml
@@ -1,5 +1,5 @@
 # Rabbitmq lookup
-- include: ubuntu.yml
-  when: 
+- include_tasks: ubuntu.yml
+  when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'trusty'

--- a/tests/integration/targets/rabbitmq_user_limits/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_user_limits/tasks/main.yml
@@ -1,5 +1,5 @@
 # Rabbitmq lookup
-- include: ubuntu.yml
-  when: 
+- include_tasks: ubuntu.yml
+  when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'trusty'

--- a/tests/integration/targets/rabbitmq_vhost_limits/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_vhost_limits/tasks/main.yml
@@ -1,5 +1,5 @@
 # Rabbitmq lookup
-- include: ubuntu.yml
-  when: 
+- include_tasks: ubuntu.yml
+  when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'trusty'

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,3 @@
-tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang
 plugins/module_utils/version.py pylint:unused-import
 tests/unit/compat/builtins.py pylint:unused-import

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -30,7 +30,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) == dict
+        assert type(file_mapping) is dict
 
         super(DictDataLoader, self).__init__()
 


### PR DESCRIPTION
ansible-core devel is dropping controller support for Python 3.9, we need to update the base container to a newer version.

`ansible.builtin.include` is deprecated, update tests to use `include_tasks` instead.

Fix some linting issues; type comparison in loader.py and ignored test.

See https://github.com/ansible-collections/news-for-maintainers/issues/49