### PR TITLE
rabbitmq_user: Fix typo - Missing space

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -510,7 +510,7 @@ def main():
 
     for permission in permissions:
         if not permission['vhost']:
-            module.fail_json(msg="Error parsing vhost permissions: You can't"
+            module.fail_json(msg="Error parsing vhost permissions: You can't "
                                  "have an empty vhost when setting permissions")
 
     for permission in topic_permissions:


### PR DESCRIPTION
##### SUMMARY
The error out, when there isn't a vHost set is missing a space

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`rabbitmq_user`