### PR TITLE
add ansible 2.16 to tests, deprecate < 2.14

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_16
+    displayName: Sanity & Units 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.16/sanity/1'
+            - name: Units
+              test: '2.16/units/1'
+
   - stage: Ansible_2_15
     displayName: Sanity & Units 2.15
     dependsOn: []
@@ -77,30 +89,6 @@ stages:
               test: '2.14/sanity/1'
             - name: Units
               test: '2.14/units/1'
-
-  - stage: Ansible_2_13
-    displayName: Sanity & Units 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.13/sanity/1'
-            - name: Units
-              test: '2.13/units/1'
-
-  - stage: Ansible_2_12
-    displayName: Sanity & Units 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          targets:
-            - name: Sanity
-              test: '2.12/sanity/1'
-            - name: Units
-              test: '2.12/units/1'
 
 ### Docker
   - stage: Docker_devel
@@ -139,6 +127,17 @@ stages:
             #- name: Ubuntu 20.04
             #  test: ubuntu2004
 
+  - stage: Docker_2_16
+    displayName: Docker 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.16/linux/{0}/1
+          targets:
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+
   - stage: Docker_2_15
     displayName: Docker 2.15
     dependsOn: []
@@ -173,32 +172,6 @@ stages:
             #- name: Ubuntu 20.04
             #  test: ubuntu2004
 
-  - stage: Docker_2_13
-    displayName: Docker 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/linux/{0}/1
-          targets:
-            #- name: Ubuntu 18.04
-            #  test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-
-  - stage: Docker_2_12
-    displayName: Docker 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/linux/{0}/1
-          targets:
-            #- name: Ubuntu 18.04
-            #  test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-
 ### Remote
 #  - stage: Remote_devel
 #    displayName: Remote devel
@@ -223,13 +196,9 @@ stages:
       - Ansible_devel
       - Ansible_2_15
       - Ansible_2_14
-      - Ansible_2_13
-      - Ansible_2_12
       - Docker_devel
       - Docker_2_15
       - Docker_2_14
-      - Docker_2_13
-      - Docker_2_12
       #- Remote_devel
     jobs:
       - template: templates/coverage.yml

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,3 @@
+tests/utils/shippable/timing.py shebang
+plugins/module_utils/version.py pylint:unused-import
+tests/unit/compat/builtins.py pylint:unused-import

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -30,7 +30,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) is dict
+        assert isinstance(file_mapping, dict)
 
         super(DictDataLoader, self).__init__()
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -67,6 +67,7 @@ if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
     SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
     TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/rabbitmq"
     mkdir -p "${TEST_DIR}"
+    # shellcheck disable=SC2153
     cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
     cd "${TEST_DIR}"
 else


### PR DESCRIPTION
The CI isn't in a good state, let's fix it up before we try and merge in some new code and do a release!

It is a requirement to test against 2.16, so add this. While we're at it, we can deprecate the older versions of ansible < 2.14.

Fixes #162
