### PR TITLE
Adjust apply_to parameter to support additional types

### DIFF
--- a/changelogs/fragments/177-adjust-apply_to-parameter-to-support-additional-types.yml
+++ b/changelogs/fragments/177-adjust-apply_to-parameter-to-support-additional-types.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_policy - adjust the `apply_to` parameter to also accept the new options `classic_queues`, `quorum_queues` and `streams` which are supported since rabbitmq 3.12

--- a/plugins/modules/rabbitmq_policy.py
+++ b/plugins/modules/rabbitmq_policy.py
@@ -28,10 +28,11 @@ options:
     default: /
   apply_to:
     description:
-      - What the policy applies to. Requires RabbitMQ 3.2.0 or later.
+      - What the policy applies to. Requires RabbitMQ 3.2.0 or later. For classic_queues,
+        quorum_queues and streams RabbitMQ 3.12 or later is required
     type: str
     default: all
-    choices: [all, exchanges, queues]
+    choices: [all, exchanges, queues, classic_queues, quorum_queues, streams]
   pattern:
     description:
       - A regex of queues to apply the policy to. Required when
@@ -221,7 +222,7 @@ def main():
         name=dict(required=True),
         vhost=dict(default='/'),
         pattern=dict(required=False, default=None),
-        apply_to=dict(default='all', choices=['all', 'exchanges', 'queues']),
+        apply_to=dict(default='all', choices=['all', 'exchanges', 'queues', 'classic_queues', 'quorum_queues', 'streams']),
         tags=dict(type='dict', required=False, default=None),
         priority=dict(default='0'),
         node=dict(default='rabbit'),


### PR DESCRIPTION
##### SUMMARY
Adjust the apply_to parameter of the rabbitmq_policy module to accept also classic_queues, quorum_queues and streams which are supported since rabbitmq 3.12

Fixes #167 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
community.rabbitmq.rabbitmq_policy
