### PR TITLE
Correct the repository urls for the rabbitMQ packages

### DIFF
--- a/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_policy/tasks/tests.yml
@@ -9,7 +9,7 @@
       state: present
     register: result
 
-  - name: Check that the host was created successfuly
+  - name: Check that the host was created successfully
     shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
     register: ctl_result
 
@@ -18,7 +18,7 @@
       that:
         - result is changed
         - result is success
-        - '"false" in ctl_result.stdout'
+        - '"/policytest\tfalse" in ctl_result.stdout'  # value for tracing, false is disabled
 
   - name: Add host (idempotency)
     rabbitmq_vhost:

--- a/tests/integration/targets/rabbitmq_vhost/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_vhost/tasks/tests.yml
@@ -8,7 +8,7 @@
       state: present
     register: result
 
-  - name: Check that the host was created successfuly
+  - name: Check that the host was created successfully
     shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
     register: ctl_result
 
@@ -17,7 +17,7 @@
       that:
         - result is changed
         - result is success
-        - '"false" in ctl_result.stdout'  # value for tracing, false is disabled
+        - '"/policytest\tfalse" in ctl_result.stdout'  # value for tracing, false is disabled
 
   - name: Add host (idempotency)
     rabbitmq_vhost:

--- a/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -23,8 +23,7 @@
 
 - name: Add RabbitMQ main release signing key
   apt_key:
-    keyserver: "keyserver.ubuntu.com"
-    id: "0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
+    url: https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA
     state: present
   # The key for RPM release signing is different than this one.
   # These URIs each have the same *RPM* signing key:
@@ -37,20 +36,20 @@
     state: present
   loop:
     # Cloudsmith: modern Erlang repository
-    - "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key"
+    - "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"
     # Cloudsmith: RabbitMQ repository
-    - "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key"
+    - "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
 
 - name: Add RabbitMQ Erlang repository
   apt_repository:
-    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_facts.distribution_release }} main"
+    repo: "deb https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_facts.distribution_release }} main"
     filename: 'rabbitmq-erlang'
     state: present
     update_cache: yes
 
 - name: Add RabbitMQ Server repository
   apt_repository:
-    repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_facts.distribution_release }} main"
+    repo: "deb https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_facts.distribution_release }} main"
     filename: 'rabbitmq-server'
     state: present
     update_cache: yes


### PR DESCRIPTION
##### SUMMARY

The ci for integration tests have been broken due to the incorrect URL of the erlang package repo.

This PR updates the URL of the package repository, which should fix the CI.



<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
rabbit mq integration tests

##### ADDITIONAL INFORMATION
The [official docs](https://www.rabbitmq.com/docs/install-debian) that contains the new repo urls.

