### PR TITLE
RabbitMQ publish support headers

### DIFF
--- a/changelogs/fragments/182-support-headers-publish.yml
+++ b/changelogs/fragments/182-support-headers-publish.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_publish - fix support for publishing headers as a part of a message (https://github.com/ansible-collections/community.rabbitmq/pull/182)

--- a/plugins/module_utils/rabbitmq.py
+++ b/plugins/module_utils/rabbitmq.py
@@ -190,14 +190,16 @@ class RabbitClient():
                 result = self.conn_channel.queue_declare(queue='',
                                                          durable=self.params.get("durable"),
                                                          exclusive=self.params.get("exclusive"),
-                                                         auto_delete=self.params.get("auto_delete"))
+                                                         auto_delete=self.params.get("auto_delete"),
+                                                         arguments=self.params.get("headers"))
                 self.conn_channel.confirm_delivery()
                 self.queue = result.method.queue
             elif self.queue is not None and self.exchange is None:
                 self.conn_channel.queue_declare(queue=self.queue,
                                                 durable=self.params.get("durable"),
                                                 exclusive=self.params.get("exclusive"),
-                                                auto_delete=self.params.get("auto_delete"))
+                                                auto_delete=self.params.get("auto_delete"),
+                                                arguments=self.params.get("headers"))
                 self.conn_channel.confirm_delivery()
         except Exception as e:
             self.module.fail_json(msg="Queue declare issue: %s" % to_native(e))

--- a/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
+++ b/tests/integration/targets/rabbitmq_publish/tasks/ubuntu.yml
@@ -179,10 +179,10 @@
       - "'image/gif' in messages[1]['content_type']"
       - "'image.gif' in messages[1]['headers']['filename']"
       - "'Testing with proto/host/port/username/password/vhost' in messages[2]['msg']"
-#      - messages[3]['headers']['myHeader'] is defined
-#      - messages[4]['headers']['filename'] is defined
-#      - messages[4]['headers']['secondHeader'] is defined
-#
+      - messages[4]['headers']['myHeader'] is defined
+      - messages[4]['headers']['secondHeader'] is defined
+      - "'Value2' in messages[4]['headers']['secondHeader']"
+
 
 - name: Check that queue and exchange are mutually exclusive
   rabbitmq_publish:


### PR DESCRIPTION
##### SUMMARY

Add headers when running the declare queue function.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

RabbitMQ Publish
basic_publish

##### ADDITIONAL INFORMATION

When running the following Ansible task:

```
    - name: Send reindex message to queue
      community.rabbitmq.rabbitmq_publish:
        url: "amqp://user:password@192.168.0.1:5672/%2F"
        queue: "example"
        body: '{ "type": "example" }'
        content_type: "application/json"
        durable: true
        headers: 
          x-max-priority: 15
        delegate_to: localhost
```

The task would fail adding the message to the queue, due to the headers not being passed in correctly. This pull request addresses that and adds the headers to the message.


Before:

```
fatal: [192.168.0.1 -> localhost]: FAILED! => changed=false 
  msg: 'Queue declare issue: (406, "PRECONDITION_FAILED - inequivalent arg ''x-max-priority'' for queue ''example'' in vhost ''/'': received none but current is the value ''15'' of type ''signedint''")'

```

After:

```
changed: [192.168.0.1-> localhost] => changed=true 
  result:
    content_type: application/json
    msg: Successfully published to queue example
    queue: example

```

It has also been tested without passing in headers, and the play still functions as before.


