### PR TITLE
Update rabbitmq_upgrade.py

### DIFF
--- a/plugins/modules/rabbitmq_upgrade.py
+++ b/plugins/modules/rabbitmq_upgrade.py
@@ -66,7 +66,7 @@ class RabbitMqUpgrade(object):
         return False
 
     def is_maint_flag_enabled(self):
-        feature_flags = self._exec('rabbitmqctl', ['list_feature_flags', '-q'], True)
+        feature_flags = self._exec('rabbitmqctl', ['list_feature_flags', '-q', '-n', self.node], True)
         for param_item in feature_flags:
             name, state = param_item.split('\t')
             if name == 'maintenance_mode_status' and state == 'enabled':


### PR DESCRIPTION
Improve the check of maint_flag to be able to nodes different to "rabbit"

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This enhancement improves the verification of maint_flag to allow nodes different from "rabbit". The modification extends the system's functionality to handle a wider variety of node types, increasing the flexibility and applicability of the code in different scenarios. This is particularly useful in environments with heterogeneous node architectures.
