### PR TITLE
User and access data should be checked Fixes #184

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -566,7 +566,7 @@ class RabbitMqUser(object):
                 self.login_host,
                 self.login_port)
             try:
-                response = requests.get(url, auth=(self.login_user, self.login_password))
+                response = requests.get(url, auth=(self.username, self.password))
             except requests.exceptions.RequestException as exception:
                 msg = ("Error trying to request permissions "
                        "of the user %s info in rabbitmq.") % (self.username)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The password to be changed was not checked, but the one used to log in to ansible. As a result, the password is never changed.

Details were described in an open Github issue ([#184](https://github.com/ansible-collections/community.rabbitmq/issues/184)).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.rabbitmq.rabbitmq_user module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
