### PR TITLE
fix condition in update password

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -908,7 +908,7 @@ def main():
                 rabbitmq_user.get()
                 result['changed'] = True
             elif update_password == 'always':
-                if not rabbitmq_user.check_password():
+                if rabbitmq_user.check_password():
                     rabbitmq_user.change_password()
                     result['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
I've found a bug when update_password=always via api

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ADDITIONAL INFORMATION
There is incorrect condition. rabbitmq_user.check_password() returns true if everything is fine. But change password will be run only when rabbitmq_user.check_password() return false
