### PR TITLE
Fix rabbitmq_binding idempotency when arguments are given (#160)

### DIFF
--- a/changelogs/fragments/191-fix-rabbitmq-binding-idempotency-with-arguments-and-or-routing-key.yml
+++ b/changelogs/fragments/191-fix-rabbitmq-binding-idempotency-with-arguments-and-or-routing-key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_binding - fix idempotency when arguments and/or routing_key are given (https://github.com/ansible-collections/community.rabbitmq/pull/191)

--- a/plugins/modules/rabbitmq_binding.py
+++ b/plugins/modules/rabbitmq_binding.py
@@ -115,12 +115,11 @@ class RabbitMqBinding(object):
         self.base_url = '{0}://{1}:{2}/api/bindings'.format(self.login_protocol,
                                                             self.login_host,
                                                             self.login_port)
-        self.url = '{0}/{1}/e/{2}/{3}/{4}/{5}'.format(self.base_url,
-                                                      urllib_parse.quote(self.vhost, safe=''),
-                                                      urllib_parse.quote(self.name, safe=''),
-                                                      self.destination_type,
-                                                      urllib_parse.quote(self.destination, safe=''),
-                                                      self.props)
+        self.url = '{0}/{1}/e/{2}/{3}/{4}'.format(self.base_url,
+                                                  urllib_parse.quote(self.vhost, safe=''),
+                                                  urllib_parse.quote(self.name, safe=''),
+                                                  self.destination_type,
+                                                  urllib_parse.quote(self.destination, safe=''))
         self.result = {
             'changed': False,
             'name': self.module.params['name'],
@@ -171,7 +170,10 @@ class RabbitMqBinding(object):
         """
         :return:
         """
-        return self.http_check_states.get(self.api_result.status_code, False)
+        for binding in self.api_result.json():
+            if binding["arguments"] == self.arguments and binding["routing_key"] == self.routing_key:
+                return True
+        return False
 
     def check_mode(self):
         """
@@ -240,11 +242,6 @@ class RabbitMqBinding(object):
         """
         :return:
         """
-        self.url = '{0}/{1}/e/{2}/{3}/{4}'.format(self.base_url,
-                                                  urllib_parse.quote(self.vhost, safe=''),
-                                                  urllib_parse.quote(self.name, safe=''),
-                                                  self.destination_type,
-                                                  urllib_parse.quote(self.destination, safe=''))
         self.api_result = self.request.post(self.url,
                                             auth=self.authentication,
                                             verify=self.verify,
@@ -255,11 +252,22 @@ class RabbitMqBinding(object):
                                                 'arguments': self.arguments
                                             }))
 
+    def get_properties_key(self):
+        """
+        :return:
+        """
+        for binding in self.api_result.json():
+            if binding["arguments"] == self.arguments and binding["routing_key"] == self.routing_key:
+                return binding["properties_key"]
+        return None
+
     def remove(self):
         """
         :return:
         """
-        self.api_result = self.request.delete(self.url, auth=self.authentication, verify=self.verify, cert=(self.cert, self.key))
+        properties_key = self.get_properties_key()
+        url = '{0}/{1}'.format(self.url, properties_key)
+        self.api_result = self.request.delete(url, auth=self.authentication, verify=self.verify, cert=(self.cert, self.key))
 
     def fail(self):
         """

--- a/plugins/modules/rabbitmq_binding.py
+++ b/plugins/modules/rabbitmq_binding.py
@@ -111,7 +111,6 @@ class RabbitMqBinding(object):
         self.verify = self.module.params['ca_cert']
         self.cert = self.module.params['client_cert']
         self.key = self.module.params['client_key']
-        self.props = urllib_parse.quote(self.routing_key) if self.routing_key != '' else '~'
         self.base_url = '{0}://{1}:{2}/api/bindings'.format(self.login_protocol,
                                                             self.login_host,
                                                             self.login_port)

--- a/tests/integration/targets/rabbitmq_binding/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_binding/tasks/tests.yml
@@ -102,6 +102,297 @@
         that:
           - remove_binding.changed == false
 
+- name: Test add binding with arguments in check mode
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+      check_mode: true
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with arguments
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with arguments idempotence
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+      register: add_binding
+
+    - name: Check that binding succeeds without a change
+      assert:
+        that:
+          - add_binding.changed == false
+
+- name: Test remove binding with arguments in check mode
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        state: absent
+      check_mode: true
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with arguments
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with arguments idempotence
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == false
+
+- name: Test add binding with routing_key in check mode
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+      check_mode: true
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with routing_key
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with routing_key idempotence
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+      register: add_binding
+
+    - name: Check that binding succeeds without a change
+      assert:
+        that:
+          - add_binding.changed == false
+
+- name: Test remove binding with routing_key in check mode
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+        state: absent
+      check_mode: true
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with routing_key
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with routing_key idempotence
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        routing_key: priority
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == false
+
+- name: Test add binding with arguments and routing_key in check mode
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+      check_mode: true
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with arguments and routing_key
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+      register: add_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - add_binding.changed == true
+
+- name: Test add binding with arguments and routing_key idempotence
+  block:
+    - name: Add binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+      register: add_binding
+
+    - name: Check that binding succeeds without a change
+      assert:
+        that:
+          - add_binding.changed == false
+
+- name: Test remove binding with arguments and routing_key in check mode
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+        state: absent
+      check_mode: true
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with arguments and routing_key
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == true
+
+- name: Test remove binding with arguments and routing_key idempotence
+  block:
+    - name: Remove binding
+      rabbitmq_binding:
+        source: exchange-foo
+        destination: queue-foo
+        type: queue
+        arguments: {"x-match": all}
+        routing_key: priority
+        state: absent
+      register: remove_binding
+
+    - name: Check that binding succeeds with a change
+      assert:
+        that:
+          - remove_binding.changed == false
+
 - name: Test add exchange to exchange binding
   block:
     - name: Add binding


### PR DESCRIPTION
##### SUMMARY
Fixes #160

##### ISSUE TYPE
* Bugfix Pull Request

##### COMPONENT NAME
community.rabbitmq.rabbitmq_binding

##### ADDITIONAL INFORMATION

This PR is a replacement for the 2 year old PR #161 as the original author @oneoneonepig did not respond to a question by @csmart for nearly a year and the bug is still not fixed, so I decided to create a new PR so we can get this bug fixed.

Copied from #161:

> Tested locally by running the same task twice. The second run shows all test cases `[ok]: ...`. See issue #160 to see what test cases were included.