### PR TITLE
rabbitmq_vhost: add REST APIs support

### DIFF
--- a/changelogs/fragments/193-api-managed-vhosts.yaml
+++ b/changelogs/fragments/193-api-managed-vhosts.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_vhost - add support to vhost manipulation through RabbitMQ API (https://github.com/ansible-collections/community.rabbitmq/issues/171)

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -265,7 +265,7 @@ class RabbitMqVhost(object):
         except requests.exceptions.RequestException as exception:
             msg = "Error in HTTP request (method %s) for user %s in rabbitmq." % (
                 method,
-                self.username,
+                self.login_user,
             )
             self.module.fail_json(msg=msg, exception=exception)
 

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -43,13 +43,11 @@ options:
       description:
           - RabbitMQ user for connection.
       type: str
-      default: guest
       version_added: '1.5.0'
   login_password:
       description:
           - RabbitMQ password for connection.
       type: str
-      default: guest
       version_added: '1.5.0'
   login_host:
       description:
@@ -280,8 +278,8 @@ def main():
         tracing=dict(default="off", aliases=["trace"], type="bool"),
         state=dict(default="present", choices=["present", "absent"]),
         node=dict(default="rabbit"),
-        login_user=dict(type="str", no_log=True, default="guest"),
-        login_password=dict(type="str", no_log=True, default="guest"),
+        login_user=dict(type="str", no_log=True),
+        login_password=dict(type="str", no_log=True),
         login_host=dict(type="str"),
         login_port=dict(type="str", default="15672"),
         login_protocol=dict(type="str", default="http", choices=["http", "https"]),

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -5,9 +5,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: rabbitmq_vhost
 short_description: Manage the state of a virtual host in RabbitMQ
@@ -52,7 +53,6 @@ options:
       description:
           - RabbitMQ host for connection.
       type: str
-      default: localhost
   login_port:
       description:
           - RabbitMQ management API port.
@@ -79,9 +79,9 @@ options:
           - Private key matching the client certificate.
       type: path
       aliases: [ key ]
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Ensure that the vhost /test exists.
   community.rabbitmq.rabbitmq_vhost:
     name: /test
@@ -94,14 +94,16 @@ EXAMPLES = r'''
     login_host: localhost
     login_user: admin
     login_password: changeadmin
-'''
+"""
 
 import traceback
 from ansible.module_utils.six.moves.urllib import parse
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 REQUESTS_IMP_ERR = None
 try:
     import requests
+
     HAS_REQUESTS = True
 except ImportError:
     REQUESTS_IMP_ERR = traceback.format_exc()
@@ -111,11 +113,21 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 class RabbitMqVhost(object):
-    def __init__(self, module, name, tracing, node, 
-                 login_user, login_password, login_host, login_port, 
-                 login_protocol, 
-                 ca_cert, client_cert, client_key
-                ):
+    def __init__(
+        self,
+        module,
+        name,
+        tracing,
+        node,
+        login_user,
+        login_password,
+        login_host,
+        login_port,
+        login_protocol,
+        ca_cert,
+        client_cert,
+        client_key,
+    ):
         self.module = module
         self.name = name
         self.tracing = tracing
@@ -130,11 +142,13 @@ class RabbitMqVhost(object):
         self.key = client_key
 
         self._tracing = False
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = module.get_bin_path("rabbitmqctl", True)
 
     def _exec(self, args, force_exec_in_check_mode=False):
-        if not self.module.check_mode or (self.module.check_mode and force_exec_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
+        if not self.module.check_mode or (
+            self.module.check_mode and force_exec_in_check_mode
+        ):
+            cmd = [self._rabbitmqctl, "-q", "-n", self.node]
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -152,16 +166,16 @@ class RabbitMqVhost(object):
                 self.module.fail_json(
                     msg="Error getting the vhost",
                     status=response.status_code,
-                    details=response.text
+                    details=response.text,
                 )
         else:
-            vhosts = self._exec(['list_vhosts', 'name', 'tracing'], True)
+            vhosts = self._exec(["list_vhosts", "name", "tracing"], True)
 
             for vhost in vhosts:
-                if '\t' not in vhost:
+                if "\t" not in vhost:
                     continue
 
-                name, tracing = vhost.split('\t')
+                name, tracing = vhost.split("\t")
                 if name == self.name:
                     self._tracing = self.module.boolean(tracing)
                     return True
@@ -172,22 +186,24 @@ class RabbitMqVhost(object):
             response = self._request_vhost_api("put")
 
             if not response.ok:
-                msg = ("Error trying to create vhost %s in rabbitmq. "
-                       "Status code '%s'.") % (self.name, response.status_code)
+                msg = (
+                    "Error trying to create vhost %s in rabbitmq. " "Status code '%s'."
+                ) % (self.name, response.status_code)
                 self.module.fail_json(msg=msg)
         else:
-            return self._exec(['add_vhost', self.name])
+            return self._exec(["add_vhost", self.name])
 
     def delete(self):
         if self.login_host is not None:
             response = self._request_vhost_api("delete")
 
             if not response.ok:
-                msg = ("Error trying to remove vhost %s in rabbitmq. "
-                       "Status code '%s'.") % (self.name, response.status_code)
+                msg = (
+                    "Error trying to remove vhost %s in rabbitmq. " "Status code '%s'."
+                ) % (self.name, response.status_code)
                 self.module.fail_json(msg=msg)
         else:
-            return self._exec(['delete_vhost', self.name])
+            return self._exec(["delete_vhost", self.name])
 
     def set_tracing(self):
         if self.tracing != self._tracing:
@@ -203,35 +219,43 @@ class RabbitMqVhost(object):
             response = self._request_vhost_api("put", data={"tracing": True})
 
             if not response.ok:
-                msg = ("Error trying to enable tracing on vhost %s in rabbitmq. "
-                       "Status code '%s'.") % (self.name, response.status_code)
+                msg = (
+                    "Error trying to enable tracing on vhost %s in rabbitmq. "
+                    "Status code '%s'."
+                ) % (self.name, response.status_code)
                 self.module.fail_json(msg=msg)
         else:
-            return self._exec(['trace_on', '-p', self.name])
+            return self._exec(["trace_on", "-p", self.name])
 
     def _disable_tracing(self):
         if self.login_host is not None:
             response = self._request_vhost_api("put", data={"tracing": False})
 
             if not response.ok:
-                msg = ("Error trying to disable tracing on vhost %s in rabbitmq. "
-                       "Status code '%s'.") % (self.name, response.status_code)
+                msg = (
+                    "Error trying to disable tracing on vhost %s in rabbitmq. "
+                    "Status code '%s'."
+                ) % (self.name, response.status_code)
                 self.module.fail_json(msg=msg)
         else:
-            return self._exec(['trace_off', '-p', self.name])
+            return self._exec(["trace_off", "-p", self.name])
 
     def _request_vhost_api(self, method, data=None):
         try:
             url = "%s://%s:%s/api/vhosts/%s" % (
-                    self.login_protocol,
-                    self.login_host,
-                    self.login_port,
-                    parse.quote(self.name, ""),
-                )
-            response = requests.request(method=method, url=url, 
-                                        auth=(self.login_user, self.login_password), 
-                                        verify=self.verify, cert=(self.cert, self.key),
-                                        json=data)
+                self.login_protocol,
+                self.login_host,
+                self.login_port,
+                parse.quote(self.name, ""),
+            )
+            response = requests.request(
+                method=method,
+                url=url,
+                auth=(self.login_user, self.login_password),
+                verify=self.verify,
+                cert=(self.cert, self.key),
+                json=data,
+            )
 
         except requests.exceptions.RequestException as exception:
             msg = "Error in HTTP request (method %s) for user %s in rabbitmq." % (
@@ -239,67 +263,76 @@ class RabbitMqVhost(object):
                 self.username,
             )
             self.module.fail_json(msg=msg, exception=exception)
-        
+
         return response
-    
+
+
 def main():
     arg_spec = dict(
-        name=dict(required=True, aliases=['vhost']),
-        tracing=dict(default='off', aliases=['trace'], type='bool'),
-        state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
-        login_user=dict(type="str", no_log=True),
-        login_password=dict(type="str", no_log=True),
+        name=dict(required=True, aliases=["vhost"]),
+        tracing=dict(default="off", aliases=["trace"], type="bool"),
+        state=dict(default="present", choices=["present", "absent"]),
+        node=dict(default="rabbit"),
+        login_user=dict(type="str", no_log=True, default="guest"),
+        login_password=dict(type="str", no_log=True, default="guest"),
         login_host=dict(type="str"),
         login_port=dict(type="str", default="15672"),
         login_protocol=dict(type="str", default="http", choices=["http", "https"]),
-        ca_cert=dict(type="path", aliases=['cacert']),
-        client_cert=dict(type="path", aliases=['cert']),
-        client_key=dict(type="path", aliases=['key']),
+        ca_cert=dict(type="path", aliases=["cacert"]),
+        client_cert=dict(type="path", aliases=["cert"]),
+        client_key=dict(type="path", aliases=["key"]),
     )
 
-    module = AnsibleModule(
-        argument_spec=arg_spec,
-        supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
     if not HAS_REQUESTS:
-        module.fail_json(msg=missing_required_lib("requests"), exception=REQUESTS_IMP_ERR)
+        module.fail_json(
+            msg=missing_required_lib("requests"), exception=REQUESTS_IMP_ERR
+        )
 
-    name = module.params['name']
-    tracing = module.params['tracing']
-    state = module.params['state']
-    node = module.params['node']
-    login_user = module.params['login_user']
-    login_password = module.params['login_password']
-    login_host = module.params['login_host']
-    login_port = module.params['login_port']
-    login_protocol = module.params['login_protocol']
-    ca_cert = module.params['ca_cert']
-    client_cert = module.params['client_cert']
-    client_key = module.params['client_key']
+    name = module.params["name"]
+    tracing = module.params["tracing"]
+    state = module.params["state"]
+    node = module.params["node"]
+    login_user = module.params["login_user"]
+    login_password = module.params["login_password"]
+    login_host = module.params["login_host"]
+    login_port = module.params["login_port"]
+    login_protocol = module.params["login_protocol"]
+    ca_cert = module.params["ca_cert"]
+    client_cert = module.params["client_cert"]
+    client_key = module.params["client_key"]
 
     result = dict(changed=False, name=name, state=state)
-    rabbitmq_vhost = RabbitMqVhost(module, name, tracing, node, 
-                                   login_user, login_password, login_host,
-                                   login_port, login_protocol, 
-                                   ca_cert, client_cert, client_key
-                                   )
+    rabbitmq_vhost = RabbitMqVhost(
+        module,
+        name,
+        tracing,
+        node,
+        login_user,
+        login_password,
+        login_host,
+        login_port,
+        login_protocol,
+        ca_cert,
+        client_cert,
+        client_key,
+    )
 
     if rabbitmq_vhost.get():
-        if state == 'absent':
+        if state == "absent":
             rabbitmq_vhost.delete()
-            result['changed'] = True
+            result["changed"] = True
         else:
             if rabbitmq_vhost.set_tracing():
-                result['changed'] = True
-    elif state == 'present':
+                result["changed"] = True
+    elif state == "present":
         rabbitmq_vhost.add()
         rabbitmq_vhost.set_tracing()
-        result['changed'] = True
+        result["changed"] = True
 
     module.exit_json(**result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/integration/targets/rabbitmq_vhost/tasks/main.yml
+++ b/tests/integration/targets/rabbitmq_vhost/tasks/main.yml
@@ -1,2 +1,8 @@
-- import_tasks: tests.yml
-  when: ansible_distribution == 'Ubuntu'
+---
+
+- when: ansible_distribution == 'Ubuntu'
+  block:
+
+  - import_tasks: tests.yml
+
+  - import_tasks: tests_api.yml

--- a/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
@@ -1,0 +1,145 @@
+- block:
+  - set_fact:
+      vhost_name: /test
+
+  - name: Add host
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  # - name: Check that the host was created successfuly
+  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  #   register: ctl_result
+
+  - name: Check that the host is added
+    assert:
+      that:
+        - result is changed
+        - result is success
+        # - '"false" in ctl_result.stdout'
+
+  - name: Add host (idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Enable tracing
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: yes
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  # - name: Get rabbitmqctl output
+  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  #   register: ctl_result
+
+  - name: Check that tracing is enabled
+    assert:
+      that:
+        - result is changed
+        - result is success
+        # - '"true" in ctl_result.stdout'
+
+  - name: Enable tracing (idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: yes
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Disable tracing
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: no
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  # - name: Get rabbitmqctl output
+  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  #   register: ctl_result
+
+  - name: Check that tracing is disabled
+    assert:
+      that:
+        - result is changed
+        - result is success
+        # - '"false" in ctl_result.stdout' 
+
+  - name: Disable tracing (idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: no
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  - name: Remove host
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: absent
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  # - name: Get rabbitmqctl output
+  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  #   register: ctl_result
+  #   failed_when: ctl_result.rc == 0
+
+  - name: Check that the host is removed
+    assert:
+      that:
+        - result is changed
+        - result is success
+
+  - name: Remove host (idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: absent
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result
+
+  - name: Check idempotency
+    assert:
+      that:
+        - result is not changed
+
+  always:
+    - name: Remove host
+      rabbitmq_vhost:
+        name: "{{ vhost_name }}"
+        state: absent

--- a/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
@@ -26,16 +26,19 @@
       login_host: 127.0.0.1
     register: result
 
-  - name: Check that the host was created successfully
-    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  - name: Check that the host was created successfully using CLI module
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
     register: ctl_result
 
   - name: Check that the host is added
     assert:
       that:
-        - result is changed
-        - result is success
-        - '"false" in ctl_result.stdout'
+        - ctl_result is not changed
+        - ctl_result is success
+        - '"/test" in ctl_result.name'
+        - '"present" in ctl_result.state'
 
   - name: Add host (check_mode - idempotency)
     rabbitmq_vhost:
@@ -221,16 +224,19 @@
       login_host: 127.0.0.1
     register: result
 
-  - name: Get rabbitmqctl output
-    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+  - name: Check that the host was removed successfully using CLI module
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: absent
     register: ctl_result
-    failed_when: ctl_result.rc == 0
 
-  - name: Check that the host is removed
+  - name: Check that the host is added
     assert:
       that:
-        - result is changed
-        - result is success
+        - ctl_result is not changed
+        - ctl_result is success
+        - '"/test" in ctl_result.name'
+        - '"absent" in ctl_result.state'
 
   - name: Remove host (check_mode - idempotency)
     rabbitmq_vhost:

--- a/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_vhost/tasks/tests_api.yml
@@ -1,6 +1,21 @@
 - block:
   - set_fact:
-      vhost_name: /test
+      vhost_name: /test  
+
+  - name: Add host (check_mode)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode result for adding host
+    assert:
+      that:
+        - result_check_mode is success
 
   - name: Add host
     rabbitmq_vhost:
@@ -11,16 +26,32 @@
       login_host: 127.0.0.1
     register: result
 
-  # - name: Check that the host was created successfuly
-  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
-  #   register: ctl_result
+  - name: Check that the host was created successfully
+    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+    register: ctl_result
 
   - name: Check that the host is added
     assert:
       that:
         - result is changed
         - result is success
-        # - '"false" in ctl_result.stdout'
+        - '"false" in ctl_result.stdout'
+
+  - name: Add host (check_mode - idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: present
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert idempotency check_mode result
+    assert:
+      that:
+        - result_check_mode is success
+        - result_check_mode is not changed
 
   - name: Add host (idempotency)
     rabbitmq_vhost:
@@ -36,6 +67,21 @@
       that:
         - result is not changed
 
+  - name: Enable tracing (check_mode)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: yes
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode for enable tracing
+    assert:
+      that:
+        - result_check_mode is success
+
   - name: Enable tracing
     rabbitmq_vhost:
       name: "{{ vhost_name }}"
@@ -45,16 +91,32 @@
       login_host: 127.0.0.1
     register: result
 
-  # - name: Get rabbitmqctl output
-  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
-  #   register: ctl_result
+  - name: Get rabbitmqctl output
+    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+    register: ctl_result
 
   - name: Check that tracing is enabled
     assert:
       that:
         - result is changed
         - result is success
-        # - '"true" in ctl_result.stdout'
+        - '"true" in ctl_result.stdout'
+
+  - name: Enable tracing (check_mode - idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: yes
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode is not changed (idempotent)
+    assert:
+      that:
+        - result_check_mode is success
+        - result_check_mode is not changed
 
   - name: Enable tracing (idempotency)
     rabbitmq_vhost:
@@ -70,6 +132,21 @@
       that:
         - result is not changed
 
+  - name: Disable tracing (check_mode)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: no
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode for disabling tracing
+    assert:
+      that:
+        - result_check_mode is success
+
   - name: Disable tracing
     rabbitmq_vhost:
       name: "{{ vhost_name }}"
@@ -79,16 +156,32 @@
       login_host: 127.0.0.1
     register: result
 
-  # - name: Get rabbitmqctl output
-  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
-  #   register: ctl_result
+  - name: Get rabbitmqctl output
+    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+    register: ctl_result
 
   - name: Check that tracing is disabled
     assert:
       that:
         - result is changed
         - result is success
-        # - '"false" in ctl_result.stdout' 
+        - '"false" in ctl_result.stdout'
+
+  - name: Disable tracing (check_mode - idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      tracing: no
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode is not changed (idempotent)
+    assert:
+      that:
+        - result_check_mode is success
+        - result_check_mode is not changed
 
   - name: Disable tracing (idempotency)
     rabbitmq_vhost:
@@ -104,6 +197,21 @@
       that:
         - result is not changed
 
+  - name: Remove host (check_mode)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: absent
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode for remove host
+    assert:
+      that:
+        - result_check_mode is success
+
   - name: Remove host
     rabbitmq_vhost:
       name: "{{ vhost_name }}"
@@ -113,16 +221,32 @@
       login_host: 127.0.0.1
     register: result
 
-  # - name: Get rabbitmqctl output
-  #   shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
-  #   register: ctl_result
-  #   failed_when: ctl_result.rc == 0
+  - name: Get rabbitmqctl output
+    shell: "rabbitmqctl list_vhosts name tracing | grep {{ vhost_name }}"
+    register: ctl_result
+    failed_when: ctl_result.rc == 0
 
   - name: Check that the host is removed
     assert:
       that:
         - result is changed
         - result is success
+
+  - name: Remove host (check_mode - idempotency)
+    rabbitmq_vhost:
+      name: "{{ vhost_name }}"
+      state: absent
+      login_user: guest 
+      login_password: guest 
+      login_host: 127.0.0.1
+    register: result_check_mode
+    check_mode: yes
+
+  - name: Assert check_mode is not changed (idempotent removal)
+    assert:
+      that:
+        - result_check_mode is success
+        - result_check_mode is not changed
 
   - name: Remove host (idempotency)
     rabbitmq_vhost:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Implement REST APIs support. Fixes #171.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_vhost

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Followed the same behavior of user module: if host is specified the module uses APIs. I think is not the best approach in terms of code reusability, but it doesn't break stuff (probably adding a provider field can be a better implementation as initially suggested in #76).
