### PR TITLE
Fix integration tests for Ubuntu Noble

### DIFF
--- a/changelogs/fragments/200-fix-integraton-tests-for-ubuntu-noble.yaml
+++ b/changelogs/fragments/200-fix-integraton-tests-for-ubuntu-noble.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup_rabbitmq - incorrect SSL library was selected for install on Ubuntu Noble. Fix now installs the correct version on newer Ubuntu versions. (https://github.com/ansible-collections/community.rabbitmq/issues/199)

--- a/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -57,7 +57,7 @@
 # Ubuntu > 22.04 uses libssl version > 3
 - name: Select version of libbssl to use
   set_fact:
-    ssl_ver: "{{ 'libssl3' if ansible_distribution_major_version == '22' else 'libssl1.1' }}"
+    ssl_ver: "{{ 'libssl3' if ansible_distribution_major_version >= '22' else 'libssl1.1' }}"
 
 - name: Install RabbitMQ Erlang dependencies
   apt:


### PR DESCRIPTION
##### SUMMARY
Fix the version check for installing the correct SSL library on Ubuntu Noble for the integration tests.  

Fixes #199 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml`

##### ADDITIONAL INFORMATION

###### BEFORE
```
TASK [setup_rabbitmq : Select version of libbssl to use] ***********************
ok: [testhost] => {"ansible_facts": {"ssl_ver": "libssl1.1"}, "changed": false}

TASK [setup_rabbitmq : Install RabbitMQ Erlang dependencies] *******************
[ERROR]: Task failed: Module failed: No package matching 'libssl1.1' is available
Origin: /root/ansible_collections/community/rabbitmq/tests/output/.tmp/integration/lookup_rabbitmq-n9nv_lr1-ÅÑŚÌβŁÈ/tests/integration/targets/setup_rabbitmq/tasks/ubuntu.yml:62:3

60     ssl_ver: "{{ 'libssl3' if ansible_distribution_major_version == '22' else 'libssl1.1' }}"
61
62 - name: Install RabbitMQ Erlang dependencies
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "No package matching 'libssl1.1' is available"}
```
###### AFTER
```
TASK [setup_rabbitmq : Select version of libbssl to use] ***********************
ok: [testhost] => {"ansible_facts": {"ssl_ver": "libssl3"}, "changed": false}

TASK [setup_rabbitmq : Install RabbitMQ Erlang dependencies] *******************
changed: [testhost] => {"cache_update_time": 1750026430, "cache_updated": false, "changed": true, "stderr": "debconf: delaying package configuration, since apt-utils is not installed\n", "stderr_lines": ["debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libsctp1\nSuggested packages:\n  erlang erlang-manpages erlang-doc erlang-inets lksctp-tools\nThe following NEW packages will be installed:\n  erlang-asn1 erlang-base erlang-crypto erlang-mnesia erlang-os-mon\n  erlang-parsetools erlang-public-key erlang-runtime-tools erlang-snmp\n  erlang-ssl erlang-syntax-tools erlang-tftp erlang-tools erlang-xmerl\n  libsctp1\n0 upgraded, 15 newly installed, 0 to remove and 53 not upgraded.\nNeed to get 20.8 MB of archives.\nAfter this operation, 40.9 MB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu noble/main amd64 libsctp1 amd64 1.0.19+dfsg-2build1 [9146 B]\nGet:2 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-asn1 amd64 1:27.3.4-1 [882 kB]\nGet:3 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-base amd64 1:27.3.4-1 [11.4 MB]\nGet:4 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-crypto amd64 1:27.3.4-1 [171 kB]\nGet:5 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-mnesia amd64 1:27.3.4-1 [888 kB]\nGet:6 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-runtime-tools amd64 1:27.3.4-1 [235 kB]\nGet:7 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-snmp amd64 1:27.3.4-1 [1938 kB]\nGet:8 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-os-mon amd64 1:27.3.4-1 [103 kB]\nGet:9 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-parsetools amd64 1:27.3.4-1 [201 kB]\nGet:10 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-public-key amd64 1:27.3.4-1 [774 kB]\nGet:11 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-ssl amd64 1:27.3.4-1 [1809 kB]\nGet:12 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-syntax-tools amd64 1:27.3.4-1 [329 kB]\nGet:13 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-tftp amd64 1:27.3.4-1 [103 kB]\nGet:14 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-tools amd64 1:27.3.4-1 [613 kB]\nGet:15 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-xmerl amd64 1:27.3.4-1 [1326 kB]\nFetched 20.8 MB in 9s (2313 kB/s)\nSelecting previously unselected package erlang-asn1.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 22458 files and directories currently installed.)\r\nPreparing to unpack .../00-erlang-asn1_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-asn1 (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-base.\r\nPreparing to unpack .../01-erlang-base_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-base (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-crypto.\r\nPreparing to unpack .../02-erlang-crypto_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-crypto (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-mnesia.\r\nPreparing to unpack .../03-erlang-mnesia_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-mnesia (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-runtime-tools.\r\nPreparing to unpack .../04-erlang-runtime-tools_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-runtime-tools (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-snmp.\r\nPreparing to unpack .../05-erlang-snmp_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-snmp (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-os-mon.\r\nPreparing to unpack .../06-erlang-os-mon_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-os-mon (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-parsetools.\r\nPreparing to unpack .../07-erlang-parsetools_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-parsetools (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-public-key.\r\nPreparing to unpack .../08-erlang-public-key_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-public-key (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-ssl.\r\nPreparing to unpack .../09-erlang-ssl_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-ssl (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-syntax-tools.\r\nPreparing to unpack .../10-erlang-syntax-tools_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-syntax-tools (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-tftp.\r\nPreparing to unpack .../11-erlang-tftp_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-tftp (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-tools.\r\nPreparing to unpack .../12-erlang-tools_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-tools (1:27.3.4-1) ...\r\nSelecting previously unselected package erlang-xmerl.\r\nPreparing to unpack .../13-erlang-xmerl_1%3a27.3.4-1_amd64.deb ...\r\nUnpacking erlang-xmerl (1:27.3.4-1) ...\r\nSelecting previously unselected package libsctp1:amd64.\r\nPreparing to unpack .../14-libsctp1_1.0.19+dfsg-2build1_amd64.deb ...\r\nUnpacking libsctp1:amd64 (1.0.19+dfsg-2build1) ...\r\nSetting up erlang-base (1:27.3.4-1) ...\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nlogger: send message failed: Operation not permitted\r\nCreated symlink /etc/systemd/system/multi-user.target.wants/epmd.service → /usr/lib/systemd/system/epmd.service.\r\r\nCreated symlink /etc/systemd/system/sockets.target.wants/epmd.socket → /usr/lib/systemd/system/epmd.socket.\r\r\nSearching for services which depend on erlang and should be started... none found.\r\nSetting up erlang-xmerl (1:27.3.4-1) ...\r\nSetting up erlang-syntax-tools (1:27.3.4-1) ...\r\nSetting up erlang-parsetools (1:27.3.4-1) ...\r\nSetting up erlang-asn1 (1:27.3.4-1) ...\r\nSetting up erlang-tftp (1:27.3.4-1) ...\r\nSetting up libsctp1:amd64 (1.0.19+dfsg-2build1) ...\r\nSetting up erlang-mnesia (1:27.3.4-1) ...\r\nSetting up erlang-crypto (1:27.3.4-1) ...\r\nSetting up erlang-runtime-tools (1:27.3.4-1) ...\r\nSetting up erlang-tools (1:27.3.4-1) ...\r\nSetting up erlang-snmp (1:27.3.4-1) ...\r\nSetting up erlang-public-key (1:27.3.4-1) ...\r\nSetting up erlang-ssl (1:27.3.4-1) ...\r\nSetting up erlang-os-mon (1:27.3.4-1) ...\r\nProcessing triggers for libc-bin (2.39-0ubuntu8.4) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libsctp1", "Suggested packages:", "  erlang erlang-manpages erlang-doc erlang-inets lksctp-tools", "The following NEW packages will be installed:", "  erlang-asn1 erlang-base erlang-crypto erlang-mnesia erlang-os-mon", "  erlang-parsetools erlang-public-key erlang-runtime-tools erlang-snmp", "  erlang-ssl erlang-syntax-tools erlang-tftp erlang-tools erlang-xmerl", "  libsctp1", "0 upgraded, 15 newly installed, 0 to remove and 53 not upgraded.", "Need to get 20.8 MB of archives.", "After this operation, 40.9 MB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu noble/main amd64 libsctp1 amd64 1.0.19+dfsg-2build1 [9146 B]", "Get:2 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-asn1 amd64 1:27.3.4-1 [882 kB]", "Get:3 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-base amd64 1:27.3.4-1 [11.4 MB]", "Get:4 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-crypto amd64 1:27.3.4-1 [171 kB]", "Get:5 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-mnesia amd64 1:27.3.4-1 [888 kB]", "Get:6 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-runtime-tools amd64 1:27.3.4-1 [235 kB]", "Get:7 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-snmp amd64 1:27.3.4-1 [1938 kB]", "Get:8 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-os-mon amd64 1:27.3.4-1 [103 kB]", "Get:9 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-parsetools amd64 1:27.3.4-1 [201 kB]", "Get:10 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-public-key amd64 1:27.3.4-1 [774 kB]", "Get:11 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-ssl amd64 1:27.3.4-1 [1809 kB]", "Get:12 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-syntax-tools amd64 1:27.3.4-1 [329 kB]", "Get:13 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-tftp amd64 1:27.3.4-1 [103 kB]", "Get:14 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-tools amd64 1:27.3.4-1 [613 kB]", "Get:15 https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu noble/main amd64 erlang-xmerl amd64 1:27.3.4-1 [1326 kB]", "Fetched 20.8 MB in 9s (2313 kB/s)", "Selecting previously unselected package erlang-asn1.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 22458 files and directories currently installed.)", "Preparing to unpack .../00-erlang-asn1_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-asn1 (1:27.3.4-1) ...", "Selecting previously unselected package erlang-base.", "Preparing to unpack .../01-erlang-base_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-base (1:27.3.4-1) ...", "Selecting previously unselected package erlang-crypto.", "Preparing to unpack .../02-erlang-crypto_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-crypto (1:27.3.4-1) ...", "Selecting previously unselected package erlang-mnesia.", "Preparing to unpack .../03-erlang-mnesia_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-mnesia (1:27.3.4-1) ...", "Selecting previously unselected package erlang-runtime-tools.", "Preparing to unpack .../04-erlang-runtime-tools_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-runtime-tools (1:27.3.4-1) ...", "Selecting previously unselected package erlang-snmp.", "Preparing to unpack .../05-erlang-snmp_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-snmp (1:27.3.4-1) ...", "Selecting previously unselected package erlang-os-mon.", "Preparing to unpack .../06-erlang-os-mon_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-os-mon (1:27.3.4-1) ...", "Selecting previously unselected package erlang-parsetools.", "Preparing to unpack .../07-erlang-parsetools_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-parsetools (1:27.3.4-1) ...", "Selecting previously unselected package erlang-public-key.", "Preparing to unpack .../08-erlang-public-key_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-public-key (1:27.3.4-1) ...", "Selecting previously unselected package erlang-ssl.", "Preparing to unpack .../09-erlang-ssl_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-ssl (1:27.3.4-1) ...", "Selecting previously unselected package erlang-syntax-tools.", "Preparing to unpack .../10-erlang-syntax-tools_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-syntax-tools (1:27.3.4-1) ...", "Selecting previously unselected package erlang-tftp.", "Preparing to unpack .../11-erlang-tftp_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-tftp (1:27.3.4-1) ...", "Selecting previously unselected package erlang-tools.", "Preparing to unpack .../12-erlang-tools_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-tools (1:27.3.4-1) ...", "Selecting previously unselected package erlang-xmerl.", "Preparing to unpack .../13-erlang-xmerl_1%3a27.3.4-1_amd64.deb ...", "Unpacking erlang-xmerl (1:27.3.4-1) ...", "Selecting previously unselected package libsctp1:amd64.", "Preparing to unpack .../14-libsctp1_1.0.19+dfsg-2build1_amd64.deb ...", "Unpacking libsctp1:amd64 (1.0.19+dfsg-2build1) ...", "Setting up erlang-base (1:27.3.4-1) ...", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "logger: send message failed: Operation not permitted", "Created symlink /etc/systemd/system/multi-user.target.wants/epmd.service → /usr/lib/systemd/system/epmd.service.", "", "Created symlink /etc/systemd/system/sockets.target.wants/epmd.socket → /usr/lib/systemd/system/epmd.socket.", "", "Searching for services which depend on erlang and should be started... none found.", "Setting up erlang-xmerl (1:27.3.4-1) ...", "Setting up erlang-syntax-tools (1:27.3.4-1) ...", "Setting up erlang-parsetools (1:27.3.4-1) ...", "Setting up erlang-asn1 (1:27.3.4-1) ...", "Setting up erlang-tftp (1:27.3.4-1) ...", "Setting up libsctp1:amd64 (1.0.19+dfsg-2build1) ...", "Setting up erlang-mnesia (1:27.3.4-1) ...", "Setting up erlang-crypto (1:27.3.4-1) ...", "Setting up erlang-runtime-tools (1:27.3.4-1) ...", "Setting up erlang-tools (1:27.3.4-1) ...", "Setting up erlang-snmp (1:27.3.4-1) ...", "Setting up erlang-public-key (1:27.3.4-1) ...", "Setting up erlang-ssl (1:27.3.4-1) ...", "Setting up erlang-os-mon (1:27.3.4-1) ...", "Processing triggers for libc-bin (2.39-0ubuntu8.4) ..."]}
```

