### PR TITLE
Fix RabbitMQ user and vhost URL encoding

### DIFF
--- a/changelogs/fragments/206-fix-rabbitmq-user-and-vhost-url-encoding.yaml
+++ b/changelogs/fragments/206-fix-rabbitmq-user-and-vhost-url-encoding.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_user - URL encode the `vhost` and `user` fields to allow for input with '/' characters. (https://github.com/ansible-collections/community.rabbitmq/issues/205)

--- a/plugins/modules/rabbitmq_binding.py
+++ b/plugins/modules/rabbitmq_binding.py
@@ -114,6 +114,10 @@ class RabbitMqBinding(object):
         self.base_url = '{0}://{1}:{2}/api/bindings'.format(self.login_protocol,
                                                             self.login_host,
                                                             self.login_port)
+        # Ensure provided data is safe to use in a URL.
+        # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+        # NOTE: This will also encode '/' characters, as they are required
+        # to be percent encoded in the RabbitMQ management API.
         self.url = '{0}/{1}/e/{2}/{3}/{4}'.format(self.base_url,
                                                   urllib_parse.quote(self.vhost, safe=''),
                                                   urllib_parse.quote(self.name, safe=''),

--- a/plugins/modules/rabbitmq_exchange.py
+++ b/plugins/modules/rabbitmq_exchange.py
@@ -120,8 +120,12 @@ def main():
         module.params['login_protocol'],
         module.params['login_host'],
         module.params['login_port'],
-        urllib_parse.quote(module.params['vhost'], ''),
-        urllib_parse.quote(module.params['name'], '')
+        # Ensure provided data is safe to use in a URL.
+        # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+        # NOTE: This will also encode '/' characters, as they are required
+        # to be percent encoded in the RabbitMQ management API.
+        urllib_parse.quote(module.params['vhost'], safe=''),
+        urllib_parse.quote(module.params['name'], safe='')
     )
 
     if not HAS_REQUESTS:

--- a/plugins/modules/rabbitmq_queue.py
+++ b/plugins/modules/rabbitmq_queue.py
@@ -164,8 +164,12 @@ def main():
         module.params['login_protocol'],
         module.params['login_host'],
         module.params['login_port'],
-        urllib_parse.quote(module.params['vhost'], ''),
-        urllib_parse.quote(module.params['name'], '')
+        # Ensure provided data is safe to use in a URL.
+        # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+        # NOTE: This will also encode '/' characters, as they are required
+        # to be percent encoded in the RabbitMQ management API.
+        urllib_parse.quote(module.params['vhost'], safe=''),
+        urllib_parse.quote(module.params['name'], safe='')
     )
 
     if not HAS_REQUESTS:

--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -216,7 +216,7 @@ import ansible_collections.community.rabbitmq.plugins.module_utils.version as Ve
 import json  # noqa: E402
 import re  # noqa: E402
 
-from ansible.module_utils.six.moves.urllib import parse
+from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 
 import traceback
 
@@ -724,7 +724,11 @@ class RabbitMqUser(object):
             self.login_protocol,
             self.login_host,
             self.login_port,
-            parse.quote(username, ""),
+            # Ensure provided data is safe to use in a URL.
+            # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+            # NOTE: This will also encode '/' characters, as they are required
+            # to be percent encoded in the RabbitMQ management API.
+            urllib_parse.quote(username, safe=''),
         )
 
     def get_permissions_api_url_builder(self, username):
@@ -732,7 +736,11 @@ class RabbitMqUser(object):
             self.login_protocol,
             self.login_host,
             self.login_port,
-            username,
+            # Ensure provided data is safe to use in a URL.
+            # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+            # NOTE: This will also encode '/' characters, as they are required
+            # to be percent encoded in the RabbitMQ management API.
+            urllib_parse.quote(username, safe=''),
         )
 
     def get_topic_permissions_api_url_builder(self, username):
@@ -740,29 +748,41 @@ class RabbitMqUser(object):
             self.login_protocol,
             self.login_host,
             self.login_port,
-            username,
+            # Ensure provided data is safe to use in a URL.
+            # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+            # NOTE: This will also encode '/' characters, as they are required
+            # to be percent encoded in the RabbitMQ management API.
+            urllib_parse.quote(username, safe=''),
         )
 
     def permissions_api_url_builder(self, username, vhost):
-        if vhost is None or vhost == "/":
-            vhost = "%2F"
+        if vhost is None:
+            vhost = "/"
         return "%s://%s:%s/api/permissions/%s/%s" % (
             self.login_protocol,
             self.login_host,
             self.login_port,
-            vhost,
-            username,
+            # Ensure provided data is safe to use in a URL.
+            # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+            # NOTE: This will also encode '/' characters, as they are required
+            # to be percent encoded in the RabbitMQ management API.
+            urllib_parse.quote(vhost, safe=''),
+            urllib_parse.quote(username, safe=''),
         )
 
     def topic_permissions_api_url_builder(self, username, vhost):
-        if vhost is None or vhost == "/":
-            vhost = "%2F"
+        if vhost is None:
+            vhost = "/"
         return "%s://%s:%s/api/topic-permissions/%s/%s" % (
             self.login_protocol,
             self.login_host,
             self.login_port,
-            vhost,
-            username,
+            # Ensure provided data is safe to use in a URL.
+            # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+            # NOTE: This will also encode '/' characters, as they are required
+            # to be percent encoded in the RabbitMQ management API.
+            urllib_parse.quote(vhost, safe=''),
+            urllib_parse.quote(username, safe=''),
         )
 
     def treat_tags_for_api(self):

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -100,7 +100,7 @@ EXAMPLES = r"""
 """
 
 import traceback
-from ansible.module_utils.six.moves.urllib import parse
+from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 from ansible.module_utils.basic import AnsibleModule
 
 REQUESTS_IMP_ERR = None
@@ -251,7 +251,11 @@ class RabbitMqVhost(object):
                 self.login_protocol,
                 self.login_host,
                 self.login_port,
-                parse.quote(self.name, ""),
+                # Ensure provided data is safe to use in a URL.
+                # https://docs.python.org/3/library/urllib.parse.html#url-quoting
+                # NOTE: This will also encode '/' characters, as they are required
+                # to be percent encoded in the RabbitMQ management API.
+                urllib_parse.quote(self.name, safe=''),
             )
             response = requests.request(
                 method=method,

--- a/tests/integration/targets/rabbitmq_user/tasks/tests.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests.yml
@@ -123,3 +123,49 @@
       assert:
         that:
           - remove_user.changed == false
+
+- name: Test add user with '/'
+  block:
+    - set_fact:
+        vhost_name: /test
+        user_name: /john_doe
+
+    - name: Add host with '/'
+      rabbitmq_vhost:
+        name: "{{ vhost_name }}"
+        state: present
+      register: add_vhost
+
+    - name: Check that the host is added
+      assert:
+        that:
+          - add_vhost is changed
+          - add_vhost is success
+          - '"/test" in add_vhost.name'
+          - '"present" in add_vhost.state'
+
+    - name: Add user with '/'
+      rabbitmq_user:
+        user: "{{ user_name }}"
+        password: changeme
+        vhost: "{{ vhost_name }}"
+        state: present
+      register: add_user
+
+    - name: Check that the user is added
+      assert:
+        that:
+          - add_user is changed
+          - add_user is success
+          - '"/john_doe" in add_user.user'
+          - '"present" in add_user.state'
+  always:
+    - name: Remove user
+      rabbitmq_user:
+        user: "{{ user_name }}"
+        state: absent
+
+    - name: Remove host
+      rabbitmq_vhost:
+        name: "{{ vhost_name }}"
+        state: absent

--- a/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
@@ -170,6 +170,7 @@
           - add_user is changed
           - add_user is success
           - '"/john_doe" in add_user.user'
+          - '"present" in add_user.state'
   always:
     - name: Remove user
       rabbitmq_user:

--- a/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
+++ b/tests/integration/targets/rabbitmq_user/tasks/tests_api.yml
@@ -129,3 +129,60 @@
       assert:
         that:
           - remove_user.changed == false
+
+- name: Test add user with '/'
+  block:
+    - set_fact:
+        vhost_name: /test
+        user_name: /john_doe
+
+    - name: Add host with '/'
+      rabbitmq_vhost:
+        name: "{{ vhost_name }}"
+        state: present
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1
+      register: add_vhost
+
+    - name: Check that the host is added
+      assert:
+        that:
+          - add_vhost is changed
+          - add_vhost is success
+          - '"/test" in add_vhost.name'
+          - '"present" in add_vhost.state'
+
+    - name: Add user with '/'
+      rabbitmq_user:
+        user: "{{ user_name }}"
+        password: changeme
+        vhost: "{{ vhost_name }}"
+        state: present
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1
+      register: add_user
+
+    - name: Check that the user is added
+      assert:
+        that:
+          - add_user is changed
+          - add_user is success
+          - '"/john_doe" in add_user.user'
+  always:
+    - name: Remove user
+      rabbitmq_user:
+        user: "{{ user_name }}"
+        state: absent
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1
+
+    - name: Remove host
+      rabbitmq_vhost:
+        name: "{{ vhost_name }}"
+        state: absent
+        login_user: guest
+        login_password: guest
+        login_host: 127.0.0.1


### PR DESCRIPTION
##### SUMMARY

- Fixes the `rabbitmq_user` module to percent encode the vhost and username fields.
- Updates the in-code documentation to explain why the percent encoding is necessary. 
- Minor changes to ensure code continuity between modules.

Fixes #205.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`rabbitmq_user.py`

