### PR TITLE
rabbitmq_vhost: fail module if requests library is missing

### DIFF
--- a/changelogs/fragments/207-fix-rabbitmq-vhost-do-not-fallback-to-rabbitmqctl.yaml
+++ b/changelogs/fragments/207-fix-rabbitmq-vhost-do-not-fallback-to-rabbitmqctl.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_vhost - Fail module if the requests library is missing. This maintains the same behavior across all the modules.

--- a/plugins/modules/rabbitmq_vhost.py
+++ b/plugins/modules/rabbitmq_vhost.py
@@ -100,19 +100,16 @@ EXAMPLES = r"""
 """
 
 import traceback
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib import parse as urllib_parse
-from ansible.module_utils.basic import AnsibleModule
 
 REQUESTS_IMP_ERR = None
 try:
     import requests
-
     HAS_REQUESTS = True
 except ImportError:
     REQUESTS_IMP_ERR = traceback.format_exc()
     HAS_REQUESTS = False
-
-from ansible.module_utils.basic import AnsibleModule
 
 
 class RabbitMqVhost(object):
@@ -309,8 +306,7 @@ def main():
     client_key = module.params["client_key"]
 
     if not HAS_REQUESTS:
-        module.warn("requests module not present. Using RabbitMQ cli.")
-        login_host = None
+        module.fail_json(msg=missing_required_lib("requests"), exception=REQUESTS_IMP_ERR)
 
     result = dict(changed=False, name=name, state=state)
     rabbitmq_vhost = RabbitMqVhost(


### PR DESCRIPTION
##### SUMMARY
All the other RabbitMQ modules fail when the `requests` library is missing. This PR updates the logic in the `rabbitmq_vhost` module to do the same.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`rabbitmq_vhost.py`

##### ADDITIONAL INFORMATION
NOTE: This might be a breaking change, specifically if someone is relying on the current implementation that falls back to using the RabbitMQ CLI.
