### PR TITLE
Announce Python 2 support drop; add related entries to ignore-2.19.txt

### DIFF
--- a/changelogs/fragments/0-python2.yml
+++ b/changelogs/fragments/0-python2.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- collection - Python 2 support will be dropped in version 2.0.0 of this collection. Make sure you have Python 3 installed on your target machines (https://github.com/ansible-collections/community.rabbitmq/issues/214).

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,3 +1,5 @@
 tests/utils/shippable/timing.py shebang
 plugins/module_utils/version.py pylint:unused-import
 tests/unit/compat/builtins.py pylint:unused-import
+tests/unit/mock/procenv.py pylint:ansible-bad-import-from
+tests/unit/mock/yaml_helper.py pylint:ansible-bad-import-from


### PR DESCRIPTION
##### SUMMARY
Relates to https://github.com/ansible-collections/community.rabbitmq/issues/214