### PR TITLE
fix: RabbitMQ user module API response success conditions to include 201 and 204

### DIFF
--- a/plugins/modules/rabbitmq_user.py
+++ b/plugins/modules/rabbitmq_user.py
@@ -586,7 +586,7 @@ class RabbitMqUser(object):
             data = {"password": self.password, "tags": self.treat_tags_for_api() or ""}
             response = self.request_users_api('PUT', data)
 
-            if not response.ok or (response.status_code == 204):
+            if response.status_code not in (201, 204):
                 msg = ("Error trying to create user %s in rabbitmq. "
                        "Status code '%s'.") % (self.username, response.status_code)
                 self.module.fail_json(msg=msg)
@@ -607,19 +607,13 @@ class RabbitMqUser(object):
 
     def change_password(self):
         if self.login_host is not None:
-            data = {"password": self.password or "", "tags": self.tags or ""}
+            data = {"password": self.password or "", "tags": self.treat_tags_for_api() or ""}
             response = self.request_users_api('PUT', data)
 
-            if not response.ok or (response.status_code == 204):
-                msg = ("Error trying to set tags for the user %s in rabbitmq. "
+            if response.status_code not in (201, 204):
+                msg = ("Error trying to change password for the user %s in rabbitmq. "
                        "Status code '%s'.") % (self.username, response.status_code)
                 self.module.fail_json(msg=msg)
-            else:
-                self.module.fail_json(
-                    msg="Error setting tags for the user",
-                    status=response.status_code,
-                    details=response.text
-                )
         else:
             if self.password:
                 self._exec(['change_password', self.username, self.password])
@@ -631,7 +625,7 @@ class RabbitMqUser(object):
             data = {"password": self.password, "tags": self.treat_tags_for_api() or ""}
             response = self.request_users_api('PUT', data)
 
-            if not response.status_code == 204:
+            if response.status_code not in (201, 204):
                 msg = ("Error trying to set tags for the user %s in rabbitmq. "
                        "Status code '%s'.") % (self.username, response.status_code)
                 self.module.fail_json(msg=msg)


### PR DESCRIPTION
##### SUMMARY
Fixes #217 where incorrect handling of successful HTTP 204 (No Content) responses in the `rabbitmq_user` module when interacting with the RabbitMQ HTTP API.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test playbook
```
---
- name: Test rabbitmq_user module
  hosts: localhost
  gather_facts: false
  
  vars:
    rmq_host: "localhost"
    rmq_port: "15672"
    rmq_protocol: "http"
    rabbitmq_admin_user: "guest"
    rabbitmq_admin_password: "guest"
    
    test_user: "test_user"
    test_password: "initial_password"
    new_password: "updated_password"
    test_vhost: "/"

  tasks:
    - name: 1. Create the user for the first time
      community.rabbitmq.rabbitmq_user:
        user: "{{ test_user }}"
        password: "{{ test_password }}"
        tags: "management"
        vhost: "{{ test_vhost }}"
        configure_priv: ".*"
        write_priv: ".*"
        read_priv: ".*"
        state: present
        update_password: always
        login_host: "{{ rmq_host }}"
        login_port: "{{ rmq_port }}"
        login_protocol: "{{ rmq_protocol }}"
        login_user: "{{ rabbitmq_admin_user }}"
        login_password: "{{ rabbitmq_admin_password }}"

    - name: 2. Run the exact same task again
      community.rabbitmq.rabbitmq_user:
        user: "{{ test_user }}"
        password: "{{ test_password }}"
        tags: "management"
        vhost: "{{ test_vhost }}"
        configure_priv: ".*"
        write_priv: ".*"
        read_priv: ".*"
        state: present
        update_password: always
        login_host: "{{ rmq_host }}"
        login_port: "{{ rmq_port }}"
        login_protocol: "{{ rmq_protocol }}"
        login_user: "{{ rabbitmq_admin_user }}"
        login_password: "{{ rabbitmq_admin_password }}"

    - name: 3. Update the user's password (this triggered the 204 error previously)
      community.rabbitmq.rabbitmq_user:
        user: "{{ test_user }}"
        password: "{{ new_password }}"
        tags: "management"
        vhost: "{{ test_vhost }}"
        configure_priv: ".*"
        write_priv: ".*"
        read_priv: ".*"
        state: present
        update_password: always
        login_host: "{{ rmq_host }}"
        login_port: "{{ rmq_port }}"
        login_protocol: "{{ rmq_protocol }}"
        login_user: "{{ rabbitmq_admin_user }}"
        login_password: "{{ rabbitmq_admin_password }}"

    - name: 4. Update the user's tags (this triggered the 204 error previously)
      community.rabbitmq.rabbitmq_user:
        user: "{{ test_user }}"
        password: "{{ new_password }}"
        tags: "monitoring, management"
        vhost: "{{ test_vhost }}"
        configure_priv: ".*"
        write_priv: ".*"
        read_priv: ".*"
        state: present
        update_password: always
        login_host: "{{ rmq_host }}"
        login_port: "{{ rmq_port }}"
        login_protocol: "{{ rmq_protocol }}"
        login_user: "{{ rabbitmq_admin_user }}"
        login_password: "{{ rabbitmq_admin_password }}"

    - name: 5. Clean up - Remove the test user
      community.rabbitmq.rabbitmq_user:
        user: "{{ test_user }}"
        state: absent
        login_host: "{{ rmq_host }}"
        login_port: "{{ rmq_port }}"
        login_protocol: "{{ rmq_protocol }}"
        login_user: "{{ rabbitmq_admin_user }}"
        login_password: "{{ rabbitmq_admin_password }}"
```

Output Before
```
ansible-playbook  rmq-test.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Test rabbitmq_user module] *******************************************************************************************************************************

TASK [1. Create the user for the first time] **********************************************************************************************************************************
changed: [localhost]

TASK [2. Run the exact same task again ****************************************************************************************
ok: [localhost]

TASK [3. Update the user's password (this triggered the 204 error previously)] ************************************************************************************************
[ERROR]: Task failed: Module failed: Error trying to set tags for the user test_ai_user in rabbitmq. Status code '204'.
Origin: /Users/mac/Development/Oneflow/oneflow-iac-test/rmq-test.yml:54:7

52         login_password: "{{ rabbitmq_admin_password }}"
53
54     - name: 3. Update the user's password (this triggered the 204 error previously)
         ^ column 7

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error trying to set tags for the user test_ai_user in rabbitmq. Status code '204'."}

PLAY RECAP ********************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
Output After
```
ansible-playbook  rmq-test.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Test rabbitmq_user module] *******************************************************************************************************************************

TASK [1. Create the user for the first time] **********************************************************************************************************************************
changed: [localhost]

TASK [2. Run the exact same task again ****************************************************************************************
ok: [localhost]

TASK [3. Update the user's password (this triggered the 204 error previously)] ************************************************************************************************
changed: [localhost]

TASK [4. Update the user's tags (this triggered the 204 error previously)] ****************************************************************************************************
changed: [localhost]

TASK [5. Clean up - Remove the test user] *************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************
localhost                  : ok=5    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```