### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,149 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Bug report
+description: Create a report to help us improve
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Also test whether the latest release and the main branch are affected.
+        Complete all sections as described. This form is processed automatically.
+
+        [issue search]: https://github.com/ansible-collections/community.rabbitmq/search?q=is%3Aissue&type=issues
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Explain the problem briefly below.
+      placeholder: >-
+        When I try to do X with the collection from the main branch on GitHub, Y
+        breaks in a way Z under environment E. Here are the details I know about
+        this problem...
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      options:
+        - Bug Report
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Component Name
+      description: >-
+        Write the short name of the module, lookup plugin, task, or feature
+        below. Use your best guess if unsure. Do not include
+        `community.rabbitmq.`.
+      placeholder: rabbitmq_user, rabbitmq_queue, rabbitmq
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Ansible Version
+      description: >-
+        Paste verbatim output from `ansible --version` between triple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible --version
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Community.rabbitmq Version
+      description: >-
+        Paste verbatim output from
+        `ansible-galaxy collection list community.rabbitmq` between triple
+        backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-galaxy collection list community.rabbitmq
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: >-
+        If this issue has YAML that helps reproduce the problem, provide it.
+        Paste verbatim output from `ansible-config dump --only-changed` between
+        triple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-config dump --only-changed
+
+        ```
+
+  - type: textarea
+    attributes:
+      label: OS / Environment
+      description: >-
+        Provide all relevant information below, for example target OS versions,
+        RabbitMQ versions, Erlang versions, container images, or broker
+        configuration.
+      placeholder: Debian 12, RabbitMQ 3.13, Erlang 26
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Describe exactly how to reproduce the problem using a minimal test case.
+        It helps if you include the playbooks, variables, configuration, and
+        commands you used.
+
+        You can paste https://gist.github.com links for larger files.
+      value: |
+        <!-- Paste example playbooks or commands between quotes below -->
+        ```yaml (paste below)
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Results
+      description: >-
+        Describe what you expected to happen when running the steps above.
+      placeholder: >-
+        I expected X to happen because I assumed Y.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Results
+      description: |
+        Describe what actually happened. If possible, run with extra verbosity
+        (`-vvvv`).
+
+        Paste verbatim command output between triple backticks.
+      value: |
+        ```console (paste below)
+
+        ```
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true
+...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false
+contact_links:
+  - name: Security bug report
+    url: https://docs.ansible.com/projects/ansible-core/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: |
+      Please learn how to report security vulnerabilities here.
+
+      For all security-related bugs, email security@ansible.com instead of using
+      this issue tracker and you will receive a prompt response.
+
+      For more information, see
+      https://docs.ansible.com/projects/ansible/latest/community/reporting_bugs_and_features.html
+  - name: Ansible Code of Conduct
+    url: https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: Be nice to other members of the community.
+  - name: Talks to the community
+    url: https://docs.ansible.com/projects/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
+    about: Please ask and answer usage questions here.
+  - name: Working groups
+    url: https://github.com/ansible/community/wiki
+    about: Interested in improving a specific area? Become a part of a working group.
+  - name: For Enterprise
+    url: https://www.ansible.com/products/engine?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: Red Hat offers support for the Ansible Automation Platform.

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -1,0 +1,127 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Documentation report
+description: Ask us about documentation
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Also test whether the latest release and the main branch are affected.
+        Complete all sections as described. This form is processed automatically.
+
+        [issue search]: https://github.com/ansible-collections/community.rabbitmq/search?q=is%3Aissue&type=issues
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Explain the documentation problem briefly below and add suggestions to
+        wording or structure.
+
+        The documentation has an "Edit on GitHub" link on every page, which can
+        be useful for small fixes.
+      placeholder: >-
+        I was reading the collection documentation for version X and had trouble
+        understanding Y. It would be helpful if that were rephrased as Z.
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      options:
+        - Documentation Report
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Component Name
+      description: >-
+        Write the short name of the file, module, lookup plugin, task, or
+        feature below. Use your best guess if unsure. Do not include
+        `community.rabbitmq.`.
+      placeholder: rabbitmq_user
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Ansible Version
+      description: >-
+        Paste verbatim output from `ansible --version` between triple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible --version
+
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Community.rabbitmq Version
+      description: >-
+        Paste verbatim output from
+        `ansible-galaxy collection list community.rabbitmq` between triple
+        backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-galaxy collection list community.rabbitmq
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: >-
+        Paste verbatim output from `ansible-config dump --only-changed` between
+        triple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-config dump --only-changed
+
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: OS / Environment
+      description: >-
+        Provide all relevant information below, for example OS version, browser,
+        or documentation page.
+      placeholder: Fedora 40, Firefox, plugin docs page
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: |
+        Describe how this improves the documentation, such as before/after
+        wording or screenshots.
+
+        You can paste https://gist.github.com links for larger files.
+      placeholder: >-
+        When the improvement is applied, it makes X more straightforward to
+        understand.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true
+...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: Feature request
+description: Suggest an idea for this project
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Also test whether the latest release and the main branch are affected.
+        Complete all sections as described. This form is processed automatically.
+
+        [issue search]: https://github.com/ansible-collections/community.rabbitmq/search?q=is%3Aissue&type=issues
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Describe the new feature or improvement briefly below.
+      placeholder: >-
+        I am trying to do X with the collection from the main branch on GitHub,
+        and implementing Y would be helpful for me and other users because of Z.
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      options:
+        - Feature Idea
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Component Name
+      description: >-
+        Write the short name of the module or lookup plugin, or which other
+        part of the collection this feature affects. Use your best guess if
+        unsure. Do not include `community.rabbitmq.`.
+      placeholder: rabbitmq_queue
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: |
+        Describe how the feature would be used, why it is needed, and what it
+        would solve.
+
+        You can paste https://gist.github.com links for larger files.
+      value: |
+        <!-- Paste example playbooks or commands between quotes below -->
+        ```yaml (paste below)
+
+        ```
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true
+...


### PR DESCRIPTION
## Summary
- add GitHub issue forms for bug reports, documentation reports, and feature requests
- add issue template chooser config with Ansible community support/security links
- adapt the form labels, examples, and issue search links for `community.rabbitmq`

Closes #218.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "yaml ok"' .github/ISSUE_TEMPLATE/*.yml`\n- `git diff --cached --check`\n\n`ansible-test` is not installed in this environment; this change only adds `.github` issue-template metadata and does not touch collection modules or docs generated by ansible-test.\n\n## AI assistance\nThis PR was prepared with AI assistance and reviewed before submission.