### PR TITLE
Add diff support for rabbitmq_policy

### DIFF
--- a/changelogs/fragments/222-add-diff-support-for-rabbitmq_policy.yml
+++ b/changelogs/fragments/222-add-diff-support-for-rabbitmq_policy.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- rabbitmq_policy - Add support for `--diff` mode checks.
+breaking_changes:
+- Drops support for pre-3.7.0 rabbitmqctl cli in the rabbitmq_policy module as the older versions don't support the `json` formatter.

--- a/plugins/doc_fragments/_attributes.py
+++ b/plugins/doc_fragments/_attributes.py
@@ -1,0 +1,99 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+
+class ModuleDocFragment:
+
+    # Standard documentation fragment
+    DOCUMENTATION = r"""
+options: {}
+attributes:
+  check_mode:
+    description: Can run in C(check_mode) and return changed status prediction without modifying target.
+  diff_mode:
+    description: Will return details on what has changed (or possibly needs changing in C(check_mode)), when in diff mode.
+  idempotent:
+    description:
+      - When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
+      - This assumes that the system controlled/queried by the module has not changed in a relevant way.
+"""
+
+    # Should be used together with the standard fragment
+    IDEMPOTENT_NOT_MODIFY_STATE = r"""
+options: {}
+attributes:
+  idempotent:
+    support: full
+    details:
+      - This action does not modify state.
+"""
+
+    # Should be used together with the standard fragment
+    INFO_MODULE = r"""
+options: {}
+attributes:
+  check_mode:
+    support: full
+    details:
+      - This action does not modify state.
+  diff_mode:
+    support: N/A
+    details:
+      - This action does not modify state.
+"""
+
+    CONN = r"""
+options: {}
+attributes:
+  become:
+    description: Is usable alongside C(become) keywords.
+  connection:
+    description: Uses the target's configured connection information to execute code on it.
+  delegation:
+    description: Can be used in conjunction with C(delegate_to) and related keywords.
+"""
+
+    FACTS = r"""
+options: {}
+attributes:
+  facts:
+    description: Action returns an C(ansible_facts) dictionary that will update existing host facts.
+"""
+
+    # Should be used together with the standard fragment and the FACTS fragment
+    FACTS_MODULE = r"""
+options: {}
+attributes:
+  check_mode:
+    support: full
+    details:
+      - This action does not modify state.
+  diff_mode:
+    support: N/A
+    details:
+      - This action does not modify state.
+  facts:
+    support: full
+"""
+
+    FILES = r"""
+options: {}
+attributes:
+  safe_file_operations:
+    description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption.
+"""
+
+    FLOW = r"""
+options: {}
+attributes:
+  action:
+    description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller.
+  async:
+    description: Supports being used with the C(async) keyword.
+"""

--- a/plugins/modules/rabbitmq_policy.py
+++ b/plugins/modules/rabbitmq_policy.py
@@ -15,6 +15,15 @@ short_description: Manage the state of policies in RabbitMQ
 description:
   - Manage the state of a policy in RabbitMQ using rabbitmqctl or REST APIs.
 author: John Dewey (@retr0h)
+extends_documentation_fragment:
+  - community.rabbitmq._attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+  idempotent:
+    support: full
 options:
   name:
     description:
@@ -136,7 +145,6 @@ EXAMPLES = r'''
 '''
 
 import json
-import re
 import traceback
 
 from ansible_collections.community.rabbitmq.plugins.module_utils.version import LooseVersion as Version
@@ -152,6 +160,52 @@ except ImportError:
     REQUESTS_IMP_ERR = traceback.format_exc()
     HAS_REQUESTS = False
 
+class Policy(object):
+    def __init__(self, vhost, name, pattern, apply_to, definition, priority):
+        self.vhost = vhost
+        self.name = name
+        self.pattern = pattern
+        self.apply_to = apply_to
+        self.definition = definition
+        # The priority field is a non-negative integral value.
+        # https://www.rabbitmq.com/docs/priority#classic-queues
+        # https://www.rabbitmq.com/docs/priority#quorum-queues
+        self.priority = int(priority)
+
+    @staticmethod
+    def parse(policy):
+        return Policy(
+            vhost=policy['vhost'],
+            name=policy['name'],
+            pattern=policy['pattern'],
+            apply_to=policy['apply-to'],
+            definition=Policy.parse_definition(policy['definition']),
+            priority=policy['priority']
+        )
+
+    @staticmethod
+    def parse_definition(definition):
+        # Parse the definition field.
+        if isinstance(definition, str):
+            try:
+                return json.loads(definition)
+            except json.decoder.JSONDecodeError:
+                return definition
+        else:
+            return definition
+
+    def json(self):
+        return {
+            'vhost': self.vhost,
+            'name': self.name,
+            'pattern': self.pattern,
+            'apply-to': self.apply_to,
+            'definition': self.definition,
+            'priority': self.priority,
+        }
+
+    def __str__(self):
+        return json.dumps(self.json())
 
 class RabbitMqPolicy(object):
 
@@ -177,7 +231,6 @@ class RabbitMqPolicy(object):
 
         require_rabbitmqctl = self._login_host is None
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', require_rabbitmqctl)
-        self._version = self._rabbit_version()
 
     def _exec(self,
               args,
@@ -262,34 +315,6 @@ class RabbitMqPolicy(object):
 
         return response
 
-    def _rabbit_version(self):
-        if self._login_host is not None:
-            response = self._request_overview()
-
-            if response is not None and not response.ok:
-                msg = (
-                    "Error trying to retrieve rabbitmq version. "
-                    "Status code '%s'."
-                ) % (response.status_code)
-                self._module.fail_json(msg=msg)
-                return None
-
-            return Version(response.json()['rabbitmq_version'])
-        else:
-            status = self._exec(['status'], True, False, False)
-
-        # 3.7.x erlang style output
-        version_match = re.search('{rabbit,".*","(?P<version>.*)"}', status)
-        if version_match:
-            return Version(version_match.group('version'))
-
-        # 3.8.x style ouput
-        version_match = re.search('RabbitMQ version: (?P<version>.*)', status)
-        if version_match:
-            return Version(version_match.group('version'))
-
-        return None
-
     def _list_policies(self):
         if self._login_host is not None:
             response = self._request_policy_api('get', self._vhost)
@@ -303,27 +328,18 @@ class RabbitMqPolicy(object):
                 return None
 
             # PARSE THE RESPONSE DATA.
-            # The response data is a json list with field names. The logic of the code expects tab delimited strings.
-            policy_response = response.json()
-            self._module.debug(f'[list_policies] {json.dumps(policy_response)}')
-            policies = []
-            if self._version and self._version >= Version('3.7.0'):
-                for policy in policy_response:
-                    policies.append("%s\t%s\t%s\t%s\t%s\t%s" % (
-                        policy['vhost'], policy['name'], policy['pattern'], policy['apply-to'], json.dumps(policy['definition']), policy['priority']))
-            else:
-                # Prior to 3.7.0, the apply-to & pattern fields were swapped.
-                for policy in policy_response:
-                    policies.append("%s\t%s\t%s\t%s\t%s\t%s" % (
-                        policy['vhost'], policy['name'], policy['apply-to'], policy['pattern'], json.dumps(policy['definition']), policy['priority']))
-            return policies
+            policies = response.json()
+            self._module.debug(f'[list_policies] {json.dumps(policies)}')
+            return [Policy.parse(policy) for policy in policies]
 
         else:
-            if self._version and self._version >= Version('3.7.9'):
-                # Remove first header line from policies list for version > 3.7.9
-                return self._exec(['list_policies'], True)[1:]
+            policies = json.loads(self._exec(['list_policies', '--formatter', 'json'], True, False))
+            self._module.debug(f'[list_policies] {json.dumps(policies)}')
+            return [Policy.parse(policy) for policy in policies]
 
-            return self._exec(['list_policies'], True)
+    def get_policy_definition(self, default={}):
+        return next(
+            (policy.json() for policy in self._list_policies() if policy.name == self._name), default)
 
     def has_modifications(self):
         if self._pattern is None or self._tags is None:
@@ -331,23 +347,16 @@ class RabbitMqPolicy(object):
                 msg=('pattern and tags are required for '
                      'state=present'))
 
-        if self._version and self._version >= Version('3.7.0'):
-            # Change fields order in rabbitmqctl output in version 3.7
-            return not any(
-                self._policy_check(policy, apply_to_fno=3, pattern_fno=2)
-                for policy in self._list_policies())
-        else:
-            return not any(
-                self._policy_check(policy) for policy in self._list_policies())
+        return not any(
+            self._policy_check(policy) for policy in self._list_policies())
 
     def should_be_deleted(self):
         return any(
             self._policy_check_by_name(policy)
             for policy in self._list_policies())
 
-    def set(self):
-        if self._login_host is not None:
-            policy = {
+    def json(self):
+        return {
                 "vhost": self._vhost,
                 "name": self._name,
                 "pattern": self._pattern,
@@ -355,6 +364,10 @@ class RabbitMqPolicy(object):
                 "definition": self._tags,
                 "priority": int(self._priority)  # Priority must be a number.
             }
+
+    def set(self):
+        if self._login_host is not None:
+            policy = self.json()
             self._module.debug(f'[set_policy] {json.dumps(policy)}')
             response = self._request_policy_api('put', self._vhost, self._name, data=policy)
 
@@ -389,40 +402,19 @@ class RabbitMqPolicy(object):
         else:
             return self._exec(['clear_policy', self._name])
 
-    def _policy_check(self,
-                      policy,
-                      name_fno=1,
-                      apply_to_fno=2,
-                      pattern_fno=3,
-                      tags_fno=4,
-                      priority_fno=5):
+    def _policy_check(self, policy):
         if not policy:
             return False
 
-        policy_data = policy.split('\t')
-
-        policy_name = policy_data[name_fno]
-        apply_to = policy_data[apply_to_fno]
-        pattern = policy_data[pattern_fno].replace('\\\\', '\\')
-
-        try:
-            tags = json.loads(policy_data[tags_fno])
-        except json.decoder.JSONDecodeError:
-            tags = policy_data[tags_fno]
-
-        priority = policy_data[priority_fno]
-
-        return (policy_name == self._name and apply_to == self._apply_to
-                and tags == self._tags and priority == self._priority
-                and pattern == self._pattern)
+        return (policy.name == self._name and policy.apply_to == self._apply_to
+                and policy.definition == self._tags and policy.priority == int(self._priority)
+                and policy.pattern == self._pattern)
 
     def _policy_check_by_name(self, policy):
         if not policy:
             return False
 
-        policy_name = policy.split('\t')[1]
-
-        return policy_name == self._name
+        return policy.name == self._name
 
 
 def main():
@@ -432,6 +424,12 @@ def main():
         pattern=dict(required=False, default=None),
         apply_to=dict(default='all', choices=['all', 'exchanges', 'queues', 'classic_queues', 'quorum_queues', 'streams']),
         tags=dict(type='dict', required=False, default=None),
+        # The priority field is a non-negative integral value.
+        # https://www.rabbitmq.com/docs/priority#classic-queues
+        # https://www.rabbitmq.com/docs/priority#quorum-queues
+        # This module does not support setting blanket policies
+        # https://www.rabbitmq.com/docs/policies#blanket
+        # which have negative values.
         priority=dict(default='0'),
         node=dict(default='rabbit'),
         state=dict(default='present', choices=['present', 'absent']),
@@ -461,11 +459,23 @@ def main():
     result = dict(changed=False, name=name, state=state)
 
     if state == 'present' and rabbitmq_policy.has_modifications():
+        # NOTE: This needs to be retrieved before the policy is modified.
+        cluster_policy = rabbitmq_policy.get_policy_definition()
         rabbitmq_policy.set()
         result['changed'] = True
+        result['diff'] = dict(
+            before=cluster_policy,
+            after=rabbitmq_policy.json()
+        )
     elif state == 'absent' and rabbitmq_policy.should_be_deleted():
+        # NOTE: This needs to be retrieved before the policy is removed.
+        cluster_policy = rabbitmq_policy.get_policy_definition()
         rabbitmq_policy.clear()
         result['changed'] = True
+        result['diff'] = dict(
+            before=cluster_policy,
+            after={}
+        )
 
     module.exit_json(**result)
 

--- a/plugins/modules/rabbitmq_policy.py
+++ b/plugins/modules/rabbitmq_policy.py
@@ -147,7 +147,6 @@ EXAMPLES = r'''
 import json
 import traceback
 
-from ansible_collections.community.rabbitmq.plugins.module_utils.version import LooseVersion as Version
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 
@@ -159,6 +158,7 @@ try:
 except ImportError:
     REQUESTS_IMP_ERR = traceback.format_exc()
     HAS_REQUESTS = False
+
 
 class Policy(object):
     def __init__(self, vhost, name, pattern, apply_to, definition, priority):
@@ -206,6 +206,7 @@ class Policy(object):
 
     def __str__(self):
         return json.dumps(self.json())
+
 
 class RabbitMqPolicy(object):
 
@@ -337,7 +338,7 @@ class RabbitMqPolicy(object):
             self._module.debug(f'[list_policies] {json.dumps(policies)}')
             return [Policy.parse(policy) for policy in policies]
 
-    def get_policy_definition(self, default={}):
+    def get_policy_definition(self, default=None):
         return next(
             (policy.json() for policy in self._list_policies() if policy.name == self._name), default)
 
@@ -357,13 +358,12 @@ class RabbitMqPolicy(object):
 
     def json(self):
         return {
-                "vhost": self._vhost,
-                "name": self._name,
-                "pattern": self._pattern,
-                "apply-to": self._apply_to,
-                "definition": self._tags,
-                "priority": int(self._priority)  # Priority must be a number.
-            }
+            "vhost": self._vhost,
+            "name": self._name,
+            "pattern": self._pattern,
+            "apply-to": self._apply_to,
+            "definition": self._tags,
+            "priority": int(self._priority)}  # Priority must be a number.
 
     def set(self):
         if self._login_host is not None:
@@ -460,7 +460,7 @@ def main():
 
     if state == 'present' and rabbitmq_policy.has_modifications():
         # NOTE: This needs to be retrieved before the policy is modified.
-        cluster_policy = rabbitmq_policy.get_policy_definition()
+        cluster_policy = rabbitmq_policy.get_policy_definition({})
         rabbitmq_policy.set()
         result['changed'] = True
         result['diff'] = dict(
@@ -469,7 +469,7 @@ def main():
         )
     elif state == 'absent' and rabbitmq_policy.should_be_deleted():
         # NOTE: This needs to be retrieved before the policy is removed.
-        cluster_policy = rabbitmq_policy.get_policy_definition()
+        cluster_policy = rabbitmq_policy.get_policy_definition({})
         rabbitmq_policy.clear()
         result['changed'] = True
         result['diff'] = dict(


### PR DESCRIPTION
##### SUMMARY

Adds support for `--diff` mode output for the `rabbitmq_policy` module. This is useful in conjunction with `--check` to verify policies before applying them to the RabbitMQ cluster.

**Breaking change:** This updates the `rabbitmqctl` command to use the json formatter, which is only available starting in version 3.7.0. See this [post](https://groups.google.com/g/rabbitmq-users/c/x0XugmBt-IE) for more info.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`rabbitmq_policy.py`

##### ADDITIONAL INFORMATION
- Adding Policies
```diff
TASK [Configure the policy] ************
--- before
+++ after
@@ -1 +1,10 @@
-{}
+{
+    "apply-to": "all",
+    "definition": {
+        "expires": 3600000
+    },
+    "name": "test-expire",
+    "pattern": ".*",
+    "priority": 0,
+    "vhost": "/"
+}

changed: [rabbitmq-mq1] => (item=test-expire)
--- before
+++ after
@@ -1 +1,13 @@
-{}
+{
+    "apply-to": "all",
+    "definition": {
+        "expires": 3600000,
+        "ha-mode": "all",
+        "ha-promote-on-shutdown": "always",
+        "ha-sync-mode": "automatic"
+    },
+    "name": "test-expire-ha",
+    "pattern": ".*",
+    "priority": 0,
+    "vhost": "/"
+}

changed: [rabbitmq-mq1] => (item=test-expire-ha)
```
- Modifying policies
```diff
TASK [ Configure the policy] ************
--- before
+++ after
@@ -1,7 +1,7 @@
 {
     "apply-to": "all",
     "definition": {
-        "expires": 3600000
+        "expires": 7200000
     },
     "name": "test-expire",
     "pattern": ".*",

changed: [rabbitmq-mq1] => (item=test-expire)
--- before
+++ after
@@ -1,7 +1,7 @@
 {
     "apply-to": "all",
     "definition": {
-        "expires": 3600000,
+        "expires": 7200000,
         "ha-mode": "all",
         "ha-promote-on-shutdown": "always",
         "ha-sync-mode": "automatic"

changed: [rabbitmq-mq1] => (item=test-expire-ha)
```
- Removing policies
```diff
TASK [Configure the policy] ************
--- before
+++ after
@@ -1,10 +1 @@
-{
-    "apply-to": "all",
-    "definition": {
-        "expires": 7200000
-    },
-    "name": "test-expire",
-    "pattern": ".*",
-    "priority": 0,
-    "vhost": "/"
-}
+{}

changed: [rabbitmq-mq1] => (item=test-expire)
--- before
+++ after
@@ -1,13 +1 @@
-{
-    "apply-to": "all",
-    "definition": {
-        "expires": 7200000,
-        "ha-mode": "all",
-        "ha-promote-on-shutdown": "always",
-        "ha-sync-mode": "automatic"
-    },
-    "name": "test-expire-ha",
-    "pattern": ".*",
-    "priority": 0,
-    "vhost": "/"
-}
+{}
changed: [rabbitmq-mq1] => (item=test-expire-ha)
```
