### PR TITLE
Deprecate RabbitMQ < 3.7 and ansible-core < 2.16

### DIFF
--- a/changelogs/fragments/20260608-deprecate_rabbitmq_lt_3.7.yml
+++ b/changelogs/fragments/20260608-deprecate_rabbitmq_lt_3.7.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- Support for RabbitMQ versions prior to 3.7.0 will be dropped in version 2.0.0 of this collection
+  (https://github.com/ansible-collections/community.rabbitmq/issues/224).

--- a/changelogs/fragments/20260608-deprecate_rabbitmq_lt_3.7.yml
+++ b/changelogs/fragments/20260608-deprecate_rabbitmq_lt_3.7.yml
@@ -1,3 +1,5 @@
 deprecated_features:
 - Support for RabbitMQ versions prior to 3.7.0 will be dropped in version 2.0.0 of this collection
   (https://github.com/ansible-collections/community.rabbitmq/issues/224).
+- Support for ansible-core versions prior to 2.16.0 will be dropped in version 2.0.0 of this collection
+  (https://github.com/ansible-collections/community.rabbitmq/issues/224).


### PR DESCRIPTION
Fixes #224

##### SUMMARY
Announce that RabbitMQ versions prior to 3.7.0 and ansible-core < 2.16 are deprecated and will be removed in 2.0.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
all / whole collection

##### ADDITIONAL INFORMATION
This somehow resulted from #222, so I'm not 100% sure if RabbitMQ < 3.7.0 should be deprecated for the whole collection or only for `rabbitmq_policy`. But as far as I understand, 3.7.0 was released in 2018 and it makes sense to drop support for older versions completely. If you want to keep support for older versions in other modules, just tell me and I'll update the changelog fragment accordingly.